### PR TITLE
[#6] Add CmpConfiguration parsing logic

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,6 +34,7 @@ module.exports = {
             'ignoreRegExpLiterals': true,
             'code': 120
         }],
+        'import/export': 1,
         'no-multiple-empty-lines': ['error', {'max': 1, 'maxEOF': 0, 'maxBOF': 0}],
         'require-jsdoc': [1],
         'semi': ['error', 'always'],

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/*
 .dist/*
 node_modules/*
+lib/*

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "tsc",
     "build:check": "tsc --noEmit",
     "lint": "eslint 'src/**/*.{js,ts}' --quiet --fix",
-    "prettier-format": "prettier --config .prettierrc.js 'src/**/*.ts' --write",
+    "prettier:format": "prettier --config .prettierrc.js 'src/**/*.ts' --write",
     "clean:build": "prettier --config .prettierrc.json 'src/**/*.ts' --write && eslint 'src/**/*.{js,ts}' --quiet --fix && tsc"
   },
   "repository": {

--- a/src/DependencyInjection/index.ts
+++ b/src/DependencyInjection/index.ts
@@ -1,0 +1,1 @@
+export * from './DependencyInjectionManager';

--- a/src/EventDispatcher/index.ts
+++ b/src/EventDispatcher/index.ts
@@ -1,0 +1,3 @@
+export * from './BaseEvent';
+export * from './EventDispatcher';
+export * from './EventSubscriberInterface';

--- a/src/Service/CmpConfiguration/CmpConfiguration.ts
+++ b/src/Service/CmpConfiguration/CmpConfiguration.ts
@@ -1,0 +1,45 @@
+import ConfigurationInterface from './ConfigurationInteface';
+
+/**
+ * CmpConfiguration.
+ */
+class CmpConfiguration {
+
+    private _isAmp: boolean;
+    private _onConsentAdsCallBack: (consents: number[]) => void;
+    private _debug: boolean;
+
+    /**
+     * Constructor.
+     *
+     * @param {ConfigurationInterface} configuration
+     */
+    constructor(configuration: ConfigurationInterface) {
+
+        this._onConsentAdsCallBack = configuration.onConsentAds;
+        this._isAmp = configuration.isAmp;
+        this._debug = configuration.debug;
+
+    }
+
+    get isAmp(): boolean {
+
+        return this._isAmp;
+
+    }
+
+    get onConsentAdsCallBack(): any {
+
+        return this._onConsentAdsCallBack;
+
+    }
+
+    get debug(): boolean {
+
+        return this._debug;
+
+    }
+
+}
+
+export default CmpConfiguration;

--- a/src/Service/CmpConfiguration/ConfigurationInteface.ts
+++ b/src/Service/CmpConfiguration/ConfigurationInteface.ts
@@ -1,0 +1,10 @@
+/**
+ * ConfigurationInterface.
+ */
+interface ConfigurationInterface {
+    isAmp: boolean;
+    onConsentAds: (consents: number[]) => void;
+    debug: boolean;
+}
+
+export default ConfigurationInterface;

--- a/src/Service/CmpConfiguration/index.ts
+++ b/src/Service/CmpConfiguration/index.ts
@@ -1,0 +1,2 @@
+export * from './CmpConfiguration';
+export * from './ConfigurationInteface';

--- a/src/Service/CmpConfigurationProvider.ts
+++ b/src/Service/CmpConfigurationProvider.ts
@@ -19,20 +19,26 @@ class CmpConfigurationProvider {
 
         if (typeof cmpConfig !== 'object' || cmpConfig === null) {
 
-            throw new Error('CmpConfig object must be provided, see docs!');
+            throw new Error('CmpConfig parameter must be provided, see docs!');
 
         }
 
         if (typeof cmpConfig.isAmp !== 'boolean') {
+
             throw new Error('CmpConfig, isAmp parameter must be a boolean.');
+
         }
 
         if (typeof cmpConfig.onConsentAds !== 'function') {
+
             throw new Error('CmpConfig, onConsentAds parameter must be a function.');
+
         }
 
         if (typeof cmpConfig.debug !== 'boolean') {
-            throw new Error('CmpConfig, debug parameter must be a boolean.')
+
+            throw new Error('CmpConfig, debug parameter must be a boolean.');
+
         }
 
         const configuration: ConfigurationInterface = {

--- a/src/Service/CmpConfigurationProvider.ts
+++ b/src/Service/CmpConfigurationProvider.ts
@@ -23,6 +23,18 @@ class CmpConfigurationProvider {
 
         }
 
+        if (typeof cmpConfig.isAmp !== 'boolean') {
+            throw new Error('CmpConfig, isAmp parameter must be a boolean.');
+        }
+
+        if (typeof cmpConfig.onConsentAds !== 'function') {
+            throw new Error('CmpConfig, onConsentAds parameter must be a function.');
+        }
+
+        if (typeof cmpConfig.debug !== 'boolean') {
+            throw new Error('CmpConfig, debug parameter must be a boolean.')
+        }
+
         const configuration: ConfigurationInterface = {
             isAmp: cmpConfig.isAmp,
             onConsentAds: cmpConfig.onConsentAds,

--- a/src/Service/CmpConfigurationProvider.ts
+++ b/src/Service/CmpConfigurationProvider.ts
@@ -1,0 +1,49 @@
+import CmpConfiguration from './CmpConfiguration/CmpConfiguration';
+import ConfigurationInterface from './CmpConfiguration/ConfigurationInteface';
+
+/**
+ * CmpConfigurationProvider.
+ */
+class CmpConfigurationProvider {
+
+    private cmpConfiguration: CmpConfiguration;
+
+    /**
+     * Constructor.
+     *
+     * @param {object} configurationObject
+     */
+    constructor(configurationObject: any) {
+
+        const cmpConfig = configurationObject;
+
+        if (typeof cmpConfig !== 'object' || cmpConfig === null) {
+
+            throw new Error('CmpConfig object must be provided, see docs!');
+
+        }
+
+        const configuration: ConfigurationInterface = {
+            isAmp: cmpConfig.isAmp,
+            onConsentAds: cmpConfig.onConsentAds,
+            debug: cmpConfig.debug,
+        };
+
+        this.cmpConfiguration = new CmpConfiguration(configuration);
+
+    }
+
+    /**
+     * Retrieve the CmpConfiguration instance.
+     *
+     * @return {CmpConfiguration}
+     */
+    getCmpConfiguration(): CmpConfiguration {
+
+        return this.cmpConfiguration;
+
+    }
+
+}
+
+export default CmpConfigurationProvider;

--- a/src/Service/index.ts
+++ b/src/Service/index.ts
@@ -1,0 +1,4 @@
+export * from './Cookie';
+export * from './Logger';
+export * from './CmpConfigurationProvider';
+export * from './CmpConfiguration';

--- a/src/SoloCmp.ts
+++ b/src/SoloCmp.ts
@@ -2,6 +2,7 @@ import {IContainer} from 'bottlejs';
 import DependencyInjectionManager from './DependencyInjection/DependencyInjectionManager';
 import Logger from './Service/Logger';
 import Cookie from './Service/Cookie';
+import CmpConfigurationProvider from './Service/CmpConfigurationProvider';
 
 /**
  * SoloCmp.
@@ -10,15 +11,18 @@ class SoloCmp {
 
     private _DependencyInjectionManager = DependencyInjectionManager;
     private isDebugEnabled: boolean;
+    private cmpConfig: any;
 
     /**
      * Constructor.
      *
      * @param {boolean} isDebugEnabled
+     * @param {object} cmpConfig
      */
-    constructor(isDebugEnabled: boolean) {
+    constructor(isDebugEnabled: boolean, cmpConfig: any) {
 
         this.isDebugEnabled = isDebugEnabled;
+        this.cmpConfig = cmpConfig;
 
         this.registerServices();
         this.registerSubscribers();
@@ -29,6 +33,7 @@ class SoloCmp {
      * Register all default services.
      */
     registerServices(): void {
+
         this._DependencyInjectionManager
             .addServiceProvider(Logger.name, () => {
 
@@ -40,7 +45,13 @@ class SoloCmp {
                 return new Cookie(container[Logger.name], window.location.hostname, document);
 
             })
-      ;
+            .addServiceProvider(CmpConfigurationProvider.name, () => {
+
+                return new CmpConfigurationProvider(this.cmpConfig);
+
+            })
+        ;
+
     }
 
     /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,4 @@
-// eslint-disable-next-line
-console.log('Hello!');
+export * from './SoloCmp';
+export * from './Service';
+export * from './EventDispatcher';
+export * from './DependencyInjection';

--- a/test/Service/CmpConfigurationProvider.test.ts
+++ b/test/Service/CmpConfigurationProvider.test.ts
@@ -1,0 +1,73 @@
+import { expect } from "chai";
+import CmpConfigurationProvider from "../../src/Service/CmpConfigurationProvider";
+import CmpConfiguration from "../../src/Service/CmpConfiguration/CmpConfiguration";
+
+describe("CmpConfigurationProvider suit test", () => {
+
+    it("CmpConfigurationProvider construction test", () => {
+
+        const cmpConfig = {
+            isAmp: false,
+            onConsentAds: (purposesAccepted) => { purposesAccepted.includes(1); },
+            debug: true
+        };
+
+        const cmpConfigurationProvider: CmpConfigurationProvider = new CmpConfigurationProvider(cmpConfig);
+
+        const cmpConfiguration: CmpConfiguration = cmpConfigurationProvider.getCmpConfiguration();
+
+        expect(cmpConfiguration.debug).to.be.true;
+        expect(cmpConfiguration.isAmp).to.be.false;
+        expect(cmpConfiguration.onConsentAdsCallBack).to.deep.equal(cmpConfig.onConsentAds);
+
+    });
+
+    it("CmpConfigurationProvider construction thrown if wrong isAmp parameter is provided test", () => {
+
+        const cmpConfig = {
+            isAmp: 'false',
+            onConsentAds: () => {},
+            debug: true,
+        };
+
+        const construction = function () {
+            new CmpConfigurationProvider(cmpConfig);
+        };
+
+        expect(construction).to.throw('CmpConfig, isAmp parameter must be a boolean.');
+
+    });
+
+    it("CmpConfigurationProvider construction thrown if wrong onConsentAds parameter is provided test", () => {
+
+        const cmpConfig = {
+            isAmp: false,
+            onConsentAds: false,
+            debug: true,
+        };
+
+        const construction = function () {
+            new CmpConfigurationProvider(cmpConfig);
+        };
+
+        expect(construction).to.throw('CmpConfig, onConsentAds parameter must be a function.');
+
+    });
+
+    it("CmpConfigurationProvider construction thrown if wrong debug parameter is provided test", () => {
+
+        const cmpConfig = {
+            isAmp: false,
+            onConsentAds: () => {},
+            debug: 'true',
+        };
+
+        const construction = function () {
+            new CmpConfigurationProvider(cmpConfig);
+        };
+
+        expect(construction).to.throw('CmpConfig, debug parameter must be a boolean.');
+
+    });
+
+});

--- a/test/Service/CmpConfigurationProvider.test.ts
+++ b/test/Service/CmpConfigurationProvider.test.ts
@@ -22,6 +22,16 @@ describe("CmpConfigurationProvider suit test", () => {
 
     });
 
+    it("CmpConfigurationProvider construction thrown if wrong config parameter is null test", () => {
+
+        const construction = function () {
+            new CmpConfigurationProvider(null);
+        };
+
+        expect(construction).to.throw('CmpConfig parameter must be provided, see docs!');
+
+    });
+
     it("CmpConfigurationProvider construction thrown if wrong isAmp parameter is provided test", () => {
 
         const cmpConfig = {


### PR DESCRIPTION
The goal of this PR:
- Add logic that can parse the configurations that publishers require within the library stream.

Issue code [#6]