### PR TITLE
[#13] Add Orchestrator logic

### DIFF
--- a/src/DependencyInjection/DependencyInjectionManager.ts
+++ b/src/DependencyInjection/DependencyInjectionManager.ts
@@ -77,9 +77,11 @@ class DependencyInjectionManager {
 
         const subscriber = provider(this.getSubContainer('service'));
 
+        const eventDispatcher = EventDispatcher.getInstance();
+
         for (const [key, methodName] of Object.entries(subscriber.getSubscribedEvents())) {
 
-            EventDispatcher.subscribe(name, key, (eventObject): void => subscriber[methodName](eventObject));
+            eventDispatcher.subscribe(name, key, (eventObject): void => subscriber[methodName](eventObject));
 
         }
 

--- a/src/Event/ConsentReadyEvent.ts
+++ b/src/Event/ConsentReadyEvent.ts
@@ -1,0 +1,38 @@
+import BaseEvent from '../EventDispatcher/BaseEvent';
+
+/**
+ * ConsentReadyEvent.
+ */
+class ConsentReadyEvent implements BaseEvent {
+
+    private readonly _tcString: string;
+    private readonly _acString: string;
+
+    /**
+     * Constructor.
+     *
+     * @param {string} tcString
+     * @param {string} acString
+     */
+    constructor(tcString: string, acString: string) {
+
+        this._tcString = tcString;
+        this._acString = acString;
+
+    }
+
+    get tcString(): string {
+
+        return this._tcString;
+
+    }
+
+    get acString(): string {
+
+        return this._acString;
+
+    }
+
+}
+
+export default ConsentReadyEvent;

--- a/src/Event/OpenCmpUIEvent.ts
+++ b/src/Event/OpenCmpUIEvent.ts
@@ -1,0 +1,38 @@
+import BaseEvent from '../EventDispatcher/BaseEvent';
+
+/**
+ * OpenCmpUIEvent.
+ */
+class OpenCmpUIEvent implements BaseEvent {
+
+    private readonly _tcString: string;
+    private readonly _acString: string;
+
+    /**
+     * Constructor.
+     *
+     * @param {string} tcString
+     * @param {string} acString
+     */
+    constructor(tcString = '', acString = '') {
+
+        this._tcString = tcString;
+        this._acString = acString;
+
+    }
+
+    get tcString(): string {
+
+        return this._tcString;
+
+    }
+
+    get acString(): string {
+
+        return this._acString;
+
+    }
+
+}
+
+export default OpenCmpUIEvent;

--- a/src/EventDispatcher/EventDispatcher.ts
+++ b/src/EventDispatcher/EventDispatcher.ts
@@ -4,6 +4,7 @@ import BaseEvent from './BaseEvent';
  * EventDispatcher.
  */
 class EventDispatcher {
+    private static instance: EventDispatcher;
 
     /**
      * subscriptions format:
@@ -12,6 +13,17 @@ class EventDispatcher {
     private subscriptions: any = {};
     private subscriptionsInfo: any = {};
     private getNextUniqueId = EventDispatcher.getIdGenerator();
+
+    /**
+     * Retrieve the instance or build it if is not instantiated.
+     */
+    public static getInstance(): EventDispatcher {
+        if (!EventDispatcher.instance) {
+            EventDispatcher.instance = new EventDispatcher();
+        }
+
+        return EventDispatcher.instance;
+    }
 
     /**
      * Subscribe a method to a specific event
@@ -110,7 +122,4 @@ class EventDispatcher {
 
 }
 
-const instance = new EventDispatcher();
-Object.freeze(instance);
-
-export default instance;
+export default EventDispatcher;

--- a/src/EventDispatcher/EventDispatcher.ts
+++ b/src/EventDispatcher/EventDispatcher.ts
@@ -4,6 +4,7 @@ import BaseEvent from './BaseEvent';
  * EventDispatcher.
  */
 class EventDispatcher {
+
     private static instance: EventDispatcher;
 
     /**
@@ -16,13 +17,19 @@ class EventDispatcher {
 
     /**
      * Retrieve the instance or build it if is not instantiated.
+     *
+     * @return {EventDispatcher}
      */
     public static getInstance(): EventDispatcher {
+
         if (!EventDispatcher.instance) {
+
             EventDispatcher.instance = new EventDispatcher();
+
         }
 
         return EventDispatcher.instance;
+
     }
 
     /**

--- a/src/Service/Orchestrator.ts
+++ b/src/Service/Orchestrator.ts
@@ -1,0 +1,91 @@
+import ConsentReadyEvent from '../Event/ConsentReadyEvent';
+import OpenCmpUIEvent from '../Event/OpenCmpUIEvent';
+import UIConstructor from '../UIConstructor';
+import TCStringService from './TCStringService';
+import ACStringService from './ACStringService';
+import EventDispatcher from '../EventDispatcher/EventDispatcher';
+
+/**
+ * Orchestrator.
+ */
+class Orchestrator {
+
+    private tcStringService: TCStringService;
+    private acStringService: ACStringService;
+    private uiConstructor: UIConstructor;
+    private eventDispatcher: EventDispatcher;
+
+    /**
+     * Constructor.
+     *
+     * @param {TCStringService} tcStringService
+     * @param {ACStringService} acStringService
+     * @param {UIConstructor} uiConstructor
+     * @param {EventDispatcher} eventDispatcher
+     */
+    constructor(
+        tcStringService: TCStringService,
+        acStringService: ACStringService,
+        uiConstructor: UIConstructor,
+        eventDispatcher: EventDispatcher,
+    ) {
+
+        this.tcStringService = tcStringService;
+        this.acStringService = acStringService;
+        this.uiConstructor = uiConstructor;
+        this.eventDispatcher = eventDispatcher;
+
+    }
+
+    /**
+     * Init the process that orchestrate the flow of the
+     * CMP, if the consent is valid it is useless to render
+     * so generate directly the ConsentReadyEvent.
+     * Otherwise, render the CMP.
+     */
+    public initCmp(): void {
+
+        const tcStringFetched = this.tcStringService.retrieveTCString();
+        const acStringFetched = this.acStringService.retrieveACString();
+
+        if (this.checkIfConsentsAreValid(tcStringFetched, acStringFetched)) {
+
+            const consentReadyEvent = new ConsentReadyEvent(tcStringFetched, acStringFetched);
+
+            this.eventDispatcher.dispatch(consentReadyEvent);
+
+            this.uiConstructor.buildOpenCmpButtonAndRender();
+
+        } else {
+
+            if (tcStringFetched.length > 0) {
+
+                this.tcStringService.removeTCString();
+                this.acStringService.removeACString();
+
+            }
+
+            this.eventDispatcher.dispatch(new OpenCmpUIEvent());
+
+        }
+
+    }
+
+    /**
+     * Check if tcString and acString are valid.
+     *
+     * @param {string} tcString
+     * @param {string} acString
+     * @private
+     *
+     * @return {boolean}
+     */
+    private checkIfConsentsAreValid(tcString: string, acString: string): boolean {
+
+        return this.tcStringService.isValidTCString(tcString) && this.acStringService.isValidACString(acString);
+
+    }
+
+}
+
+export default Orchestrator;

--- a/src/SoloCmp.ts
+++ b/src/SoloCmp.ts
@@ -1,6 +1,7 @@
 import {GVL} from '@iabtcf/core';
 import {IContainer} from 'bottlejs';
 import DependencyInjectionManager from './DependencyInjection/DependencyInjectionManager';
+import EventDispatcher from './EventDispatcher/EventDispatcher';
 import LoggerService from './Service/LoggerService';
 import CookieService from './Service/CookieService';
 import CmpConfigurationProvider from './Service/CmpConfigurationProvider';
@@ -11,6 +12,8 @@ import ACStringService from './Service/ACStringService';
 import ACModelService from './Service/ACModelService';
 import HttpRequestService from './Service/HttpRequestService';
 import CmpApiProvider from './Service/CmpApiProvider';
+import Orchestrator from './Service/Orchestrator';
+import UIConstructor from './UIConstructor';
 
 /**
  * SoloCmp.
@@ -18,12 +21,13 @@ import CmpApiProvider from './Service/CmpApiProvider';
 class SoloCmp {
 
     private _DependencyInjectionManager = DependencyInjectionManager;
-    private baseUrlVendorList: string;
+    private readonly uiConstructor: UIConstructor;
+    private readonly baseUrlVendorList: string;
     private readonly isDebugEnabled: boolean;
     private readonly cmpVersion: number;
     private readonly cmpVendorListVersion: number;
-    private cmpId: number;
-    private isServiceSpecific: boolean;
+    private readonly cmpId: number;
+    private readonly isServiceSpecific: boolean;
     private readonly tcStringCookieName: string;
     private readonly acStringLocalStorageName: string;
     private readonly cmpConfig: any;
@@ -32,6 +36,7 @@ class SoloCmp {
     /**
      * Constructor.
      *
+     * @param {UIConstructor} uiConstructor
      * @param {boolean} isDebugEnabled
      * @param {object} cmpConfig
      * @param {string[]} supportedLanguages
@@ -44,6 +49,7 @@ class SoloCmp {
      * @param {string} baseUrlVendorList
      */
     constructor(
+        uiConstructor: UIConstructor,
         isDebugEnabled: boolean,
         cmpConfig: any,
         supportedLanguages: string[],
@@ -56,6 +62,7 @@ class SoloCmp {
         baseUrlVendorList: string,
     ) {
 
+        this.uiConstructor = uiConstructor;
         this.isDebugEnabled = isDebugEnabled;
         this.cmpConfig = cmpConfig;
         this.supportedLanguages = supportedLanguages;
@@ -158,6 +165,21 @@ class SoloCmp {
                     this.cmpVersion,
                     this.isServiceSpecific,
                     container[ACStringService.name],
+                );
+
+            })
+            .addServiceProvider(EventDispatcher.name, () => {
+
+                return EventDispatcher.getInstance();
+
+            })
+            .addServiceProvider(Orchestrator.name, (container: IContainer) => {
+
+                return new Orchestrator(
+                    container[TCStringService.name],
+                    container[ACStringService.name],
+                    this.uiConstructor,
+                    container[EventDispatcher.name],
                 );
 
             });

--- a/src/UIConstructor.ts
+++ b/src/UIConstructor.ts
@@ -25,7 +25,7 @@ class UIConstructor {
 
         this.document = document;
 
-        if (domElementId.length === 0 || !/^[a-z0-9]+$/i.test(domElementId)) {
+        if (domElementId.length === 0 || !/^[a-z0-9]\D\S+$/i.test(domElementId)) {
 
             throw new Error(
                 'UIConstructor, domElementId must be a string with length greater than zero and contains only letters and numbers.',

--- a/test/EventDispatcher/EventDispatcher.test.ts
+++ b/test/EventDispatcher/EventDispatcher.test.ts
@@ -19,9 +19,11 @@ describe('EventDispatcher suit test', () => {
 
         mock.expects('method').once().withArgs(testEvent);
 
-        EventDispatcher.subscribe('SubscriberTest', testEvent.constructor.name, subscriber.method);
+        const eventDispatcher = EventDispatcher.getInstance();
 
-        EventDispatcher.dispatch(testEvent);
+        eventDispatcher.subscribe('SubscriberTest', testEvent.constructor.name, subscriber.method);
+
+        eventDispatcher.dispatch(testEvent);
 
         mock.verify();
     });

--- a/test/Service/Orchestrator.test.ts
+++ b/test/Service/Orchestrator.test.ts
@@ -1,0 +1,153 @@
+const sinon = require('sinon');
+import { TCModel, TCString } from '@iabtcf/core';
+import { TCModelFactory } from '@iabtcf/testing';
+import CmpSupportedLanguageProvider from '../../src/Service/CmpSupportedLanguageProvider';
+import TCStringService from '../../src/Service/TCStringService';
+import LoggerService from '../../src/Service/LoggerService';
+import CookieService from '../../src/Service/CookieService';
+import ACStringService from '../../src/Service/ACStringService';
+import Orchestrator from '../../src/Service/Orchestrator';
+import UIConstructor from '../../src/UIConstructor';
+import EventDispatcher from '../../src/EventDispatcher/EventDispatcher';
+import OpenCmpUIEvent from '../../src/Event/OpenCmpUIEvent';
+import ConsentReadyEvent from '../../src/Event/ConsentReadyEvent';
+
+describe('Orchestrator suit test', () => {
+    const tcModel = (TCModelFactory.withGVL() as unknown) as TCModel;
+
+    const getTCStringService = () => {
+        const loggerService: LoggerService = new LoggerService(false);
+
+        const document = {
+            cookie: '',
+        };
+
+        const mockDocument = sinon.mock(document);
+        const cookieService: CookieService = new CookieService(loggerService, 'solocmp.com', mockDocument);
+
+        const cmpSupportedLanguageProvider = new CmpSupportedLanguageProvider(
+            ['it', 'fr', 'en'],
+            tcModel.consentLanguage,
+        );
+
+        return new TCStringService(
+            cookieService,
+            loggerService,
+            cmpSupportedLanguageProvider,
+            Number(tcModel.cmpVersion),
+            Number(tcModel.vendorListVersion),
+            'solo-cmp-tc-string',
+        );
+    };
+
+    const getACStringService = () => {
+        const loggerService: LoggerService = new LoggerService(false);
+
+        return new ACStringService(
+            Number(tcModel.cmpVersion),
+            'solo-cmp-ac-string',
+            loggerService,
+            global.localStorage,
+        );
+    };
+
+    it('Orchestrator initCmp with valid consent strings render only cmp button ui test', (done) => {
+        const tcStringService = getTCStringService();
+
+        sinon.stub(tcStringService, 'retrieveTCString').callsFake(function fakeMakeRequest() {
+            return TCString.encode(tcModel);
+        });
+
+        const acStringService = getACStringService();
+
+        sinon.stub(acStringService, 'retrieveACString').callsFake(function fakeMakeRequest() {
+            return `${tcModel.cmpVersion}~`;
+        });
+
+        const cmpBuildUIAndRenderCallback = function (element: HTMLElement) {
+            done();
+        };
+
+        const uiConstructor = new UIConstructor(document, 'solo-cmp', () => {}, cmpBuildUIAndRenderCallback);
+
+        const eventDispatcher = EventDispatcher.getInstance();
+
+        var mock = sinon.mock(eventDispatcher);
+        mock.expects('dispatch')
+            .once()
+            .withExactArgs(new ConsentReadyEvent(TCString.encode(tcModel), `${tcModel.cmpVersion}~`));
+
+        const orchestrator = new Orchestrator(tcStringService, acStringService, uiConstructor, eventDispatcher);
+
+        orchestrator.initCmp();
+        mock.verify();
+    });
+
+    it('Orchestrator initCmp with invalid consent tcString dispatch OpenCmpUIEvent test', () => {
+        const tcStringService = getTCStringService();
+
+        sinon.stub(tcStringService, 'retrieveTCString').callsFake(function fakeMakeRequest() {
+            return '';
+        });
+
+        const acStringService = getACStringService();
+
+        sinon.stub(acStringService, 'retrieveACString').callsFake(function fakeMakeRequest() {
+            return `${tcModel.cmpVersion}~`;
+        });
+
+        const uiConstructor = new UIConstructor(
+            document,
+            'solo-cmp',
+            () => {},
+            () => {},
+        );
+
+        const eventDispatcher = EventDispatcher.getInstance();
+
+        var mock = sinon.mock(eventDispatcher);
+        mock.expects('dispatch').once().withExactArgs(new OpenCmpUIEvent());
+
+        const orchestrator = new Orchestrator(tcStringService, acStringService, uiConstructor, eventDispatcher);
+
+        orchestrator.initCmp();
+        mock.verify();
+    });
+
+    it('Orchestrator initCmp with invalid consent tcString remove tcString and acString test', () => {
+        const tcStringService = getTCStringService();
+
+        sinon.stub(tcStringService, 'retrieveTCString').callsFake(function fakeMakeRequest() {
+            return 'something';
+        });
+
+        const acStringService = getACStringService();
+
+        sinon.stub(acStringService, 'retrieveACString').callsFake(function fakeMakeRequest() {
+            return `${tcModel.cmpVersion}~`;
+        });
+
+        const uiConstructor = new UIConstructor(
+            document,
+            'solo-cmp',
+            () => {},
+            () => {},
+        );
+
+        var mockTCStringService = sinon.mock(tcStringService);
+        mockTCStringService.expects('removeTCString').once();
+        var mockACStringService = sinon.mock(acStringService);
+        mockACStringService.expects('removeACString').once();
+
+        const orchestrator = new Orchestrator(
+            tcStringService,
+            acStringService,
+            uiConstructor,
+            EventDispatcher.getInstance(),
+        );
+
+        orchestrator.initCmp();
+        mockTCStringService.verify();
+        mockACStringService.verify();
+    });
+});


### PR DESCRIPTION
The goal is to implement the orchestrator who decides when the consent is valid or not and what to do in case.

Issue code: [#13]

Note:
Essentially this service exposes an initCmp method that takes care of making the first check necessary to understand if it is necessary to start all the CMP otherwise it directly releases the event to which subsequently (with other PRs) will be subscribed for the logic to be executed when the consent it is ready.
