### PR TITLE
[#41] Add secure flag when doing the cookie store

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,5 +51,32 @@
   },
   "files": [
     "lib/**/*"
+  ],
+  "keywords": [
+    "solocmp",
+    "interactive",
+    "advertising",
+    "bureau",
+    "iab",
+    "transparency",
+    "consent",
+    "consentstring",
+    "tcstring",
+    "gvl",
+    "vendor",
+    "framework",
+    "tcf",
+    "lib",
+    "library",
+    "cmp",
+    "2.0",
+    "v2.0",
+    "v2",
+    "software",
+    "development",
+    "api",
+    "kit",
+    "sdk",
+    "gdpr"
   ]
 }

--- a/src/Service/CookieService.ts
+++ b/src/Service/CookieService.ts
@@ -42,7 +42,7 @@ export class CookieService {
         const expires = 'expires=' + date.toUTCString();
         const domain = CookieService.getCleanedDomain(this.hostName);
 
-        this.document.cookie = `${cookieName}=${cookieValue};${expires};path=/;domain=${domain}`;
+        this.document.cookie = `${cookieName}=${cookieValue};${expires};path=/;domain=${domain};secure`;
 
     }
 

--- a/test/Service/CookieService.test.ts
+++ b/test/Service/CookieService.test.ts
@@ -24,7 +24,7 @@ describe('Cookie suit test', () => {
         date.setTime(date.getTime() + 365 * CookieService.milliSecondsInADay);
 
         expect(mockDocument.cookie).to.equal(
-            `cookieTest=valueTest;expires=${date.toUTCString()};path=/;domain=.solocmp.com`,
+            `cookieTest=valueTest;expires=${date.toUTCString()};path=/;domain=.solocmp.com;secure`,
         );
     });
 


### PR DESCRIPTION
Cookies with SameSite=None must now also specify the Secure attribute (they require a secure context/HTTPS). https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite