### PR TITLE
[#47] Fix bug getTCData command when tcData is null

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "solo-cmp",
-  "version": "1.0.0",
+  "name": "@pubtech-ai/solo-cmp",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pubtech-ai/solo-cmp",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Wrapper of IAB module that make simple to made a CMP",
   "author": "Marco Prontera <https://github.com/Marco-Prontera>",
   "license": "Apache-2.0",

--- a/src/Service/CmpApiProvider.ts
+++ b/src/Service/CmpApiProvider.ts
@@ -22,10 +22,14 @@ export class CmpApiProvider {
     constructor(id: number, version: number, isServiceSpecific: boolean, acStringService: ACStringService) {
 
         this._cmpApi = new CmpApi(id, version, isServiceSpecific, {
-            getTCData: (next: any, tcData: any, success: any) => {
+            'getTCData': (next: any, tcData: any, success: any) => {
 
-                tcData.reallyImportantExtraProperty = true;
-                tcData.addtlConsent = acStringService.retrieveACString();
+                if (tcData) {
+
+                    tcData.reallyImportantExtraProperty = true;
+                    tcData.addtlConsent = acStringService.retrieveACString();
+
+                }
 
                 next(tcData, success);
 


### PR DESCRIPTION
The getTCData command can pass with the tcData to null and this causes a bug in the CMP validator.

Issue code: [#47]