### PR TITLE
[#49] Fix CmpApi bug for wrong example IAB documentation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pubtech-ai/solo-cmp",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pubtech-ai/solo-cmp",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "description": "Wrapper of IAB module that make simple to made a CMP",
   "author": "Marco Prontera <https://github.com/Marco-Prontera>",
   "license": "Apache-2.0",

--- a/src/Service/CmpApiProvider.ts
+++ b/src/Service/CmpApiProvider.ts
@@ -29,9 +29,9 @@ export class CmpApiProvider {
                     tcData.reallyImportantExtraProperty = true;
                     tcData.addtlConsent = acStringService.retrieveACString();
 
-                }
+                    next(tcData, success);
 
-                next(tcData, success);
+                }
 
             },
         });


### PR DESCRIPTION
The goal is to fix CmpApi bug for wrong example IAB documentation, tcData can be null and must not be provided in the next call.