### PR TITLE
[#53] Fix event dispatch error detection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pubtech-ai/solo-cmp",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pubtech-ai/solo-cmp",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Wrapper of IAB module that make simple to made a CMP",
   "author": "Marco Prontera <https://github.com/Marco-Prontera>",
   "license": "Apache-2.0",

--- a/src/EventDispatcher/EventDispatcher.ts
+++ b/src/EventDispatcher/EventDispatcher.ts
@@ -96,9 +96,9 @@ export class EventDispatcher {
                 // eslint-disable-next-line
                 console.error(
                     'Something went wrong in ' +
-                        this.subscriptionsInfo[event.constructor.name][key] +
+                        this.subscriptionsInfo[event.EVENT_NAME][key] +
                         ', subscribed to the event: \'' +
-                        event.constructor.name +
+                        event.EVENT_NAME +
                         '\'',
                     'SOLO-CMP',
                     [error],


### PR DESCRIPTION
When translating the library, an error occurs where it masks the actual error of the executed subscriber event method.