### PR TITLE
[#55] Fill PublisherTC segment with user choices

### DIFF
--- a/src/Dto/SoloCmpDto.ts
+++ b/src/Dto/SoloCmpDto.ts
@@ -4,17 +4,17 @@ import {UIConstructor} from '../UIConstructor';
  * SoloCmpDto.
  */
 export interface SoloCmpDto {
-    uiConstructor: UIConstructor,
-    isDebugEnabled: boolean,
-    cmpConfig: any,
-    supportedLanguages: string[],
-    cmpVersion: number,
-    cmpVendorListVersion: number,
-    tcStringCookieName: string,
-    acStringLocalStorageName: string,
-    cmpId: number,
-    isServiceSpecific: boolean,
-    baseUrlVendorList: string,
-    initialHeightAmpCmpUi: string | null,
-    enableBorderAmpCmpUi: boolean | null,
+    uiConstructor: UIConstructor;
+    isDebugEnabled: boolean;
+    cmpConfig: any;
+    supportedLanguages: string[];
+    cmpVersion: number;
+    cmpVendorListVersion: number;
+    tcStringCookieName: string;
+    acStringLocalStorageName: string;
+    cmpId: number;
+    isServiceSpecific: boolean;
+    baseUrlVendorList: string;
+    initialHeightAmpCmpUi: string | null;
+    enableBorderAmpCmpUi: boolean | null;
 }

--- a/src/Service/CmpApiProvider.ts
+++ b/src/Service/CmpApiProvider.ts
@@ -22,7 +22,7 @@ export class CmpApiProvider {
     constructor(id: number, version: number, isServiceSpecific: boolean, acStringService: ACStringService) {
 
         this._cmpApi = new CmpApi(id, version, isServiceSpecific, {
-            'getTCData': (next: any, tcData: any, success: any) => {
+            getTCData: (next: any, tcData: any, success: any) => {
 
                 if (tcData) {
 

--- a/src/Service/ConsentGeneratorService.ts
+++ b/src/Service/ConsentGeneratorService.ts
@@ -41,10 +41,14 @@ export class ConsentGeneratorService {
         soloCmpDataBundle: SoloCmpDataBundle,
     ): void {
 
+        const tmpGvl = soloCmpDataBundle.tcModel.gvl;
         const choicesParser = new UIChoicesParser(soloCmpDataBundle.tcModel, soloCmpDataBundle.acModel);
 
         const tcModel = choicesParser.parseTCModel(uiChoicesBridgeDto);
         const acModel = choicesParser.parseACModel(uiChoicesBridgeDto);
+
+        // REQUIRED UNTIL SOLVED https://github.com/InteractiveAdvertisingBureau/iabtcf-es/issues/297
+        tcModel.gvl = tmpGvl;
 
         const tcString = this.tcStringService.buildTCString(tcModel);
         const acString = this.acStringService.buildACString(acModel);

--- a/src/Service/TCModelService.ts
+++ b/src/Service/TCModelService.ts
@@ -89,7 +89,8 @@ export class TCModelService {
 
                 return tcModel.gvl.changeLanguage(this.cmpSupportedLanguageProvider.getCurrentLanguageForCmp());
 
-            }).then(() => {
+            })
+            .then(() => {
 
                 return tcModel;
 

--- a/src/Service/TCStringService.ts
+++ b/src/Service/TCStringService.ts
@@ -139,9 +139,13 @@ export class TCStringService {
 
         tcModelWithAllEnabled.setAll();
 
+        // REQUIRED UNTIL SOLVED https://github.com/InteractiveAdvertisingBureau/iabtcf-es/issues/179
+        tcModel.publisherConsents.set([...tcModel.purposeConsents.values()]);
+        tcModel.publisherLegitimateInterests.set([...tcModel.purposeLegitimateInterests.values()]);
+
         const tcString: string = TCString.encode(tcModelWithAllEnabled);
 
-        this.loggerService.debug('TCString all enabled built: ' + tcString);
+        this.loggerService.debug('TCString all enabled built fixeddd: ' + tcString);
 
         return tcString;
 

--- a/src/SoloCmp.ts
+++ b/src/SoloCmp.ts
@@ -55,7 +55,7 @@ export class SoloCmp {
      *
      * @param {SoloCmpDto} soloCmpDto
      */
-    constructor(soloCmpDto : SoloCmpDto) {
+    constructor(soloCmpDto: SoloCmpDto) {
 
         this.uiConstructor = soloCmpDto.uiConstructor;
         this.isDebugEnabled = soloCmpDto.isDebugEnabled;

--- a/src/UIChoicesBridge/UIChoicesParser.ts
+++ b/src/UIChoicesBridge/UIChoicesParser.ts
@@ -44,6 +44,11 @@ export class UIChoicesParser {
             this.filterEnabledChoicesId(uiChoicesBridgeDto.UILegitimateInterestsVendorChoices),
         );
 
+        this._tcModel.publisherConsents.set(this.filterEnabledChoicesId(uiChoicesBridgeDto.UIPurposeChoices));
+        this._tcModel.publisherLegitimateInterests.set(
+            this.filterEnabledChoicesId(uiChoicesBridgeDto.UILegitimateInterestsPurposeChoices),
+        );
+
         return this._tcModel;
 
     }

--- a/test/Service/TCModelService.test.ts
+++ b/test/Service/TCModelService.test.ts
@@ -84,7 +84,10 @@ describe('TCModelService suit test', () => {
     it('TCModelService buildTCModel test', async () => {
         const tcModel: TCModel = getTCModel();
 
-        const cmpSupportedLanguageProvider = new CmpSupportedLanguageProvider(['it', 'fr', 'en'], tcModel.consentLanguage + '-LN');
+        const cmpSupportedLanguageProvider = new CmpSupportedLanguageProvider(
+            ['it', 'fr', 'en'],
+            tcModel.consentLanguage + '-LN',
+        );
 
         const tcStringService = new TCStringService(
             cookieService,

--- a/test/UIChoicesBridge/UIChoicesParser.test.ts
+++ b/test/UIChoicesBridge/UIChoicesParser.test.ts
@@ -14,8 +14,9 @@ describe('UIChoicesParser suit test', () => {
 
         const choicesStateHandler = new UIChoicesBridgeDtoBuilder(tcModelInit, acModelInit).createUIChoicesBridgeDto();
 
-        //Simulate User choices changes
+        // Simulate User choices changes
         choicesStateHandler.UIPurposeChoices.forEach((purposeChoice) => (purposeChoice.state = true));
+        choicesStateHandler.UILegitimateInterestsPurposeChoices[0].state = true;
 
         expect(
             [...uiChoicesParser.tcModel.purposeConsents.values()].length,
@@ -27,6 +28,16 @@ describe('UIChoicesParser suit test', () => {
         ).to.equal(2);
 
         const tcModel = uiChoicesParser.parseTCModel(choicesStateHandler);
+
+        expect(
+            [...tcModel.publisherConsents.values()].length,
+            '[...tcModel.publisherConsents.values()].length',
+        ).to.equal(10);
+
+        expect(
+            [...tcModel.publisherLegitimateInterests.values()].length,
+            '[...tcModel.publisherLegitimateInterests.values()].length',
+        ).to.equal(1);
 
         expect([...tcModel.purposeConsents.values()].length, '[...tcModel.purposeConsents.values()].length').to.equal(
             10,


### PR DESCRIPTION
Add publisherConsents and publisherLegitimateInterest to make a PublisherTC segment with TCString generated.
These values must be caught from the legal basis presented to the user.

Note:
This PR contains code that supports a bug of IAB library. All additional code required have a reference to a issue related IAB TFC project.