### PR TITLE
[#66] Improve performance for download vendor-list.json

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,4 +1,4 @@
-name: Build and test the application
+name: Build and test
 
 on:
   pull_request:

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+Issue.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,59 @@
+# Contribution
+
+In order to contribute to the improvement of the project, below you will find the project development flow.
+Before being able to open a PR with changes to be applied or bug fixes to be solved, it is necessary to open an issue 
+and explain the reason and a possible solution. You can open each PR by forking the project and creating the PR directly from 
+your project to the project of our library.
+
+Main rules:
+- Open issue
+- Create PR from forked project
+- Link your PR to the issue
+
+## Development Flow
+
+All development work occurs on the `develop` branch.
+The `main` branch is used to create new releases by merging current head of the `develop` branch.
+You should create a feature-branch, branching from `develop`, whenever you need to add some changes to the `main` branch.
+If those changes are accepted they will be merged by the repository maintainer.
+
+## Dependencies
+
+- [IAB TCF Modules](https://github.com/InteractiveAdvertisingBureau/iabtcf-es)
+- [BottleJS](https://github.com/young-steveo/bottlejs)
+
+## Development environment
+
+To ease local development you have to install these tools:
+
+* [Node.js](https://nodejs.org/)
+
+Currently used version: [v14.15.4](https://nodejs.org/dist/v14.15.4/docs/api/)
+
+### Install dependencies
+
+To install dependencies, execute these commands:
+```sh
+npm install
+```
+
+### Test project
+
+To run tests, execute this command:
+```sh
+npm run test
+```
+
+### Lint project
+
+To lint the project files, execute this command:
+```sh
+npm run lint
+```
+
+### Compile and minify for production
+
+To create a production version, execute this command:
+```sh
+npm run build
+```

--- a/README.md
+++ b/README.md
@@ -17,8 +17,6 @@ library with the intention of simplifying and adding more ways of customization 
 
 - 🚀 Optimized consent release performance
 - 🏄 Ability to add plugins in standard flow
-- 🔑 Coverage test
-- 🙏️ Commitment to keep the APIs as similar as possible
 - ⚡️ Integration with AMP
 
 #### Guidelines

--- a/README.md
+++ b/README.md
@@ -1,15 +1,35 @@
-# solo-cmp
+# SoloCmp 🎻
 
-This library is a wrapper of the [IAB's Transparency and Consent Framework (TCF)](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework) library with the intention of simplifying and adding more ways of customization of the whole flow that starts from the view of the CMP banner at the release of the user's consent. This library is completely framework agnostic, so feel free to implement your CMP with any framework such as Vue, React and others.
-So what you have to do is only the graphical implementation and if necessary add plugins to execute logic based on the event flows mapped by the library.
+[![npm version](https://badge.fury.io/js/%40pubtech-ai%2Fsolo-cmp.svg)](https://badge.fury.io/js/%40pubtech-ai%2Fsolo-cmp.svg)
+![badge build and test](https://github.com/pubtech-ai/solo-cmp/actions/workflows/build-and-test.yml/badge.svg)
+
+#### What is it for?
+- This library is a wrapper of the [IAB's Transparency and Consent Framework (TCF)](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework) 
+library with the intention of simplifying and adding more ways of customization of the whole flow that starts from the view of the CMP banner at the release of the user's consent.
+
+#### Are there any requirements?
+- This library is completely framework agnostic, so feel free to implement your CMP with any framework such as Vue, React and others.
+
+#### What do you have to do? 
+- Implement only the UI part of the CMP, everything else is handled by SoloCmp.
+
+#### Together with the easier implementation of your CMP you have:
+
+- 🚀 Optimized consent release performance
+- 🏄 Ability to add plugins in standard flow
+- 🔑 Coverage test
+- 🙏️ Commitment to keep the APIs as similar as possible
+- ⚡️ Integration with AMP
+
+#### Guidelines
 
   - [Installation](#installation)
   - [Using](#using)
   - [Contribution](#contribution)
-
+  - [Internal Documentation](https://github.com/pubtech-ai/solo-cmp/blob/main/doc/internal-solo-cmp.md)
+  
 #### Installation
 
-npm
 ```
 npm install @pubtech-ai/solo-cmp --save
 ```
@@ -172,10 +192,8 @@ If those changes are accepted they will be merged by the repository maintainer.
 
 ## Dependencies
 
-This application is based on:
-- Node.js: 14.15.4
-- IAB TCF Modules
-- BottleJs
+- [IAB TCF Modules](https://github.com/InteractiveAdvertisingBureau/iabtcf-es)
+- [BottleJS](https://github.com/young-steveo/bottlejs)
 
 ## Development environment
 
@@ -183,20 +201,13 @@ To ease local development you have to install these tools:
 
 * [Node.js](https://nodejs.org/)
 
+Currently used version: [v14.15.4](https://nodejs.org/dist/v14.15.4/docs/api/)
+
 ### Install dependencies
 
 To install dependencies, execute these commands:
 ```sh
 npm install
-```
-
-When the process is complete, a Browser tab is automatically opened.
-
-### Compile and minify for production
-
-To create a production version, execute this command:
-```sh
-npm run build
 ```
 
 ### Test project
@@ -211,6 +222,13 @@ npm run test
 To lint the project files, execute this command:
 ```sh
 npm run lint
+```
+
+### Compile and minify for production
+
+To create a production version, execute this command:
+```sh
+npm run build
 ```
 
 ### Disclaimer

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 1.x.x   | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+This project at the moment doesn't use any dependency, but if you find any vulnerability you can open an issue.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,4 +8,5 @@
 
 ## Reporting a Vulnerability
 
-This project at the moment doesn't use any dependency, but if you find any vulnerability you can open an issue.
+Open an issue.
+Prefix the title of the issue with [SECURITY].

--- a/doc/internal-solo-cmp.md
+++ b/doc/internal-solo-cmp.md
@@ -15,7 +15,7 @@ may have arisen from the CMP UI which uses solo-cmp as the basis for the project
 Currently, there are explanations of not all flows, soon we will add all the necessary documentation.
 Meanwhile, you are starting to see the more "complex" flows.
 
-The hardest part!
+The hardest part! 💪
 
 ## Main events flows
 
@@ -28,9 +28,8 @@ This event can however be dispatched by the UI layer of the CMP for example when
 he has previously applied.
 
 Here is the complete flow of when the event dispatched:
-<p>
-    <img src="doc/sequence-diagrams/img/open-cmp-ui-event-flow.svg" />
-</p>
+
+![OpenCmpUIEvent diagram](https://github.com/pubtech-ai/solo-cmp/blob/main/doc/sequence-diagrams/img/open-cmp-ui-event-flow.svg?raw=true)
 
 ### ConsentRequiredEvent flow
 
@@ -38,9 +37,8 @@ This event dispatched when the consent requested from the user, this always happ
  of the cmp once all the data has been taken and it is possible to render the UI of the cmp.
 
 Here is the complete flow of when the event dispatched:
-<p>
-    <img src="doc/sequence-diagrams/img/consent-required-event-flow.svg" />
-</p>
+
+![ConsentRequiredEvent diagram](https://github.com/pubtech-ai/solo-cmp/blob/main/doc/sequence-diagrams/img/consent-required-event-flow.svg?raw=true)
 
 ### ApplyConsentEvent flow
 
@@ -49,9 +47,8 @@ to transmit the consents that the user has modified and then allow the library t
 persist and call any event subscribers that depend on ConsentReadyEvent.
 
 Here is the complete flow of when the event dispatched:
-<p>
-    <img src="doc/sequence-diagrams/img/apply-consent-event-flow.svg" />
-</p>
+
+![ApplyConsentEvent diagram](https://github.com/pubtech-ai/solo-cmp/blob/main/doc/sequence-diagrams/img/apply-consent-event-flow.svg?raw=true)
 
 
 ### AcceptAllEvent flow
@@ -64,6 +61,6 @@ Essentially a subscriber linked to that event that automatically generates and p
 with all possible choices enabled
 
 Here is the complete flow of when the event dispatched:
-<p>
-    <img src="doc/sequence-diagrams/img/accept-all-event-flow.svg" />
-</p>
+
+![AcceptAllEvent diagram](https://github.com/pubtech-ai/solo-cmp/blob/main/doc/sequence-diagrams/img/accept-all-event-flow.svg?raw=true)
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pubtech-ai/solo-cmp",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pubtech-ai/solo-cmp",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Wrapper of IAB module that make simple to made a CMP",
   "author": "Marco Prontera <https://github.com/Marco-Prontera>",
   "license": "Apache-2.0",
@@ -23,7 +23,7 @@
     "@iabtcf/cmpapi": "1.3.0",
     "@iabtcf/core": "1.3.0",
     "@iabtcf/stub": "1.3.0",
-    "bottlejs": "^2.0.0"
+    "bottlejs": "2.0.0"
   },
   "devDependencies": {
     "@iabtcf/testing": "1.3.0",

--- a/src/EventSubscriber/CmpCallbackSubscriber.ts
+++ b/src/EventSubscriber/CmpCallbackSubscriber.ts
@@ -1,6 +1,7 @@
 import {ConsentReadyEvent} from '../Event';
 import {EventSubscriberInterface} from '../EventDispatcher';
 import {CmpConfigurationProvider, CmpConfiguration} from '../Service';
+import {TCString} from '@iabtcf/core';
 
 /**
  * CmpCallbackSubscriber.
@@ -41,7 +42,7 @@ export class CmpCallbackSubscriber implements EventSubscriberInterface {
 
         const cmpConfiguration: CmpConfiguration = this.cmpConfigurationProvider.cmpConfiguration;
 
-        cmpConfiguration.onConsentAdsCallBack(event);
+        cmpConfiguration.onConsentAdsCallBack(event, TCString.decode(event.tcString));
 
     }
 

--- a/src/Service/CmpConfiguration/CmpConfiguration.ts
+++ b/src/Service/CmpConfiguration/CmpConfiguration.ts
@@ -1,5 +1,6 @@
 import {ConfigurationInterface} from './ConfigurationInteface';
 import {ConsentReadyEvent} from '../../Event';
+import {TCModel} from '@iabtcf/core';
 
 /**
  * CmpConfiguration.
@@ -7,7 +8,7 @@ import {ConsentReadyEvent} from '../../Event';
 export class CmpConfiguration {
 
     private readonly _isAmp: boolean;
-    private readonly _onConsentAdsCallBack: (event: ConsentReadyEvent) => void;
+    private readonly _onConsentAdsCallBack: (event: ConsentReadyEvent, tcModel: TCModel) => void;
     private readonly _debug: boolean;
 
     /**

--- a/src/Service/CmpConfiguration/ConfigurationInteface.ts
+++ b/src/Service/CmpConfiguration/ConfigurationInteface.ts
@@ -1,10 +1,11 @@
 import {ConsentReadyEvent} from '../../Event';
+import {TCModel} from '@iabtcf/core';
 
 /**
  * ConfigurationInterface.
  */
 export interface ConfigurationInterface {
     isAmp: boolean;
-    onConsentAds: (event: ConsentReadyEvent) => void;
+    onConsentAds: (event: ConsentReadyEvent, tcModel: TCModel) => void;
     debug: boolean;
 }

--- a/src/Service/TCModelService.ts
+++ b/src/Service/TCModelService.ts
@@ -1,4 +1,4 @@
-import {GVL, TCModel, TCString} from '@iabtcf/core';
+import {TCModel, TCString} from '@iabtcf/core';
 import {TCStringService} from './TCStringService';
 import {CmpSupportedLanguageProvider} from './CmpSupportedLanguageProvider';
 
@@ -10,7 +10,7 @@ export class TCModelService {
     private readonly cmpId: number;
     private readonly cmpVersion: number;
     private readonly isServiceSpecific: boolean;
-    private readonly globalVendorList: GVL;
+    private readonly globalVendorListCreatorFunction: CallableFunction;
     private tcStringService: TCStringService;
     private cmpSupportedLanguageProvider: CmpSupportedLanguageProvider;
 
@@ -22,7 +22,7 @@ export class TCModelService {
      * @param {number} cmpId
      * @param {number} cmpVersion
      * @param {boolean} isServiceSpecific
-     * @param {GVL} globalVendorList
+     * @param {CallableFunction} globalVendorListCreatorFunction
      */
     constructor(
         tcStringService: TCStringService,
@@ -30,7 +30,7 @@ export class TCModelService {
         cmpId: number,
         cmpVersion: number,
         isServiceSpecific: boolean,
-        globalVendorList: GVL,
+        globalVendorListCreatorFunction: CallableFunction,
     ) {
 
         if (Number.isNaN(cmpId)) {
@@ -50,7 +50,7 @@ export class TCModelService {
         this.cmpId = cmpId;
         this.cmpVersion = cmpVersion;
         this.isServiceSpecific = isServiceSpecific;
-        this.globalVendorList = globalVendorList;
+        this.globalVendorListCreatorFunction = globalVendorListCreatorFunction;
 
     }
 
@@ -66,7 +66,7 @@ export class TCModelService {
 
         const encodedString = tcString;
 
-        let tcModel = new TCModel(this.globalVendorList);
+        let tcModel = new TCModel(this.globalVendorListCreatorFunction());
 
         // Some fields will not be populated until a GVL is loaded
         const promise = tcModel.gvl.readyPromise

--- a/src/SoloCmp.ts
+++ b/src/SoloCmp.ts
@@ -116,9 +116,16 @@ export class SoloCmp {
             })
             .addServiceProvider(TCModelService.getClassName(), (container: IContainer) => {
 
-                GVL.baseUrl = this.baseUrlVendorList;
+                /**
+                 * @return {GVL}
+                 */
+                const createGVL = (): GVL => {
 
-                const gvl: GVL = new GVL();
+                    GVL.baseUrl = this.baseUrlVendorList;
+
+                    return new GVL();
+
+                };
 
                 return new TCModelService(
                     container[TCStringService.getClassName()],
@@ -126,7 +133,7 @@ export class SoloCmp {
                     this.cmpId,
                     this.cmpVersion,
                     this.isServiceSpecific,
-                    gvl,
+                    createGVL.bind(this),
                 );
 
             })

--- a/src/SoloCmpDataBundle.ts
+++ b/src/SoloCmpDataBundle.ts
@@ -21,12 +21,7 @@ export class SoloCmpDataBundle {
      * @param {boolean} isConsentRequest
      * @private
      */
-    constructor(
-        uiChoicesBridgeDto: UIChoicesBridgeDto,
-        tcModel: TCModel,
-        acModel: ACModel,
-        isConsentRequest: boolean,
-    ) {
+    constructor(uiChoicesBridgeDto: UIChoicesBridgeDto, tcModel: TCModel, acModel: ACModel, isConsentRequest: boolean) {
 
         this._uiChoicesBridgeDto = uiChoicesBridgeDto;
         this._tcModel = tcModel;

--- a/test/EventSubscriber/CmpCallbackSubscriber.test.ts
+++ b/test/EventSubscriber/CmpCallbackSubscriber.test.ts
@@ -1,23 +1,38 @@
-import { expect } from 'chai';
+import {expect} from 'chai';
 const sinon = require('sinon');
-import { ConsentReadyEvent, CmpConfigurationProvider, CmpCallbackSubscriber } from '../../src';
+import {ConsentReadyEvent, CmpConfigurationProvider, CmpCallbackSubscriber} from '../../src';
+import {TCModel} from '@iabtcf/core';
 
 describe('CmpCallbackSubscriber suit test', () => {
+
     it('CmpCallbackSubscriber getSubscribedEvents registered for ConsentReadyEvent test', () => {
+
         const mock = sinon.mock(Object.create(CmpConfigurationProvider));
 
         const cmpCallbackSubscriber = new CmpCallbackSubscriber(mock);
 
         expect(cmpCallbackSubscriber.getSubscribedEvents()).to.have.own.property(ConsentReadyEvent.name);
+
     });
 
     it('CmpCallbackSubscriber call callback stored inside CmpConfiguration test', (done) => {
+
+        const tcString = 'CPKMzMdPKMzMdFgACAITBjCsAP_AAH_AAAAAIEtf_X__bX9j-_59f_t0eY1P9_r_v-Qzjhfdt-8N2L_W_L0X42E7NF36pq4KuR4Eu3LBIQNlHMHUTUmw6okVrzPsak2Mr7NKJ7LEmnMZO2dYGHtfn91TuZKY7_78_9fz3z-v_v___9f3r-3_3__59X---_e_V399zLv9_____9nN__4ICAEmGpfQBdiWODJtGlUKIEYVhIdAKACigGFomsIGBwU7KwCPUELABCagIwIgQYgoxYBAAIBAEhEQEgB4IBEARAIAAQAqQEIACJgEFgBYGAQACgGhYgRQBCBIQZHBUcpgQESLRQT2VgCUXexphCGUWAFAo_oqMBEoQQLAyEhYOY4AkAAA.YAAAAAAAAAAA';
+
         const cmpConfig = {
             isAmp: false,
-            onConsentAds: (event) => {
-                if (event.tcString === 'abc') {
+            onConsentAds: (eventData, iabConsentsObject) => {
+
+                if (
+                    iabConsentsObject instanceof TCModel &&
+                    iabConsentsObject.purposeConsents.has(1) &&
+                    eventData.tcString === tcString
+                ) {
+
                     done();
+
                 }
+
             },
             debug: true,
         };
@@ -26,8 +41,10 @@ describe('CmpCallbackSubscriber suit test', () => {
 
         const cmpCallbackSubscriber = new CmpCallbackSubscriber(cmpConfigurationProvider);
 
-        const consentReadyEvent = new ConsentReadyEvent('abc', 'cba');
+        const consentReadyEvent = new ConsentReadyEvent(tcString, 'cba');
 
         cmpCallbackSubscriber[cmpCallbackSubscriber.getSubscribedEvents()[ConsentReadyEvent.name]](consentReadyEvent);
+
     });
+
 });

--- a/test/EventSubscriber/OpenCmpUISubscriber.test.ts
+++ b/test/EventSubscriber/OpenCmpUISubscriber.test.ts
@@ -95,7 +95,7 @@ describe('OpenCmpUISubscriber suit test', () => {
             Number(tcModel.cmpId),
             Number(tcModel.cmpVersion),
             true,
-            tcModel.gvl,
+            () => tcModel.gvl,
         );
 
         sinon

--- a/test/Service/CmpPreparatoryService.test.ts
+++ b/test/Service/CmpPreparatoryService.test.ts
@@ -94,7 +94,7 @@ describe('CmpPreparatoryService suit test', () => {
             Number(tcModel.cmpId),
             Number(tcModel.cmpVersion),
             true,
-            tcModel.gvl,
+            () => tcModel.gvl,
         );
 
         sinon
@@ -190,7 +190,7 @@ describe('CmpPreparatoryService suit test', () => {
             Number(tcModel.cmpId),
             Number(tcModel.cmpVersion),
             true,
-            tcModel.gvl,
+            () => tcModel.gvl,
         );
 
         sinon

--- a/test/Service/TCModelService.test.ts
+++ b/test/Service/TCModelService.test.ts
@@ -53,7 +53,7 @@ describe('TCModelService suit test', () => {
                 NaN,
                 Number(tcModel.cmpVersion),
                 true,
-                tcModel.gvl,
+                () => tcModel.gvl,
             );
         };
 
@@ -75,7 +75,7 @@ describe('TCModelService suit test', () => {
         );
 
         const construction = () => {
-            new TCModelService(tcStringService, cmpSupportedLanguageProvider, 123, NaN, true, tcModel.gvl);
+            new TCModelService(tcStringService, cmpSupportedLanguageProvider, 123, NaN, true, () => tcModel.gvl);
         };
 
         expect(construction).to.throw('TCModelService, cmpVersion parameter must be a valid number.');
@@ -104,7 +104,7 @@ describe('TCModelService suit test', () => {
             123,
             Number(tcModel.cmpVersion),
             true,
-            tcModel.gvl,
+            () => tcModel.gvl,
         );
 
         const builtTcModel: TCModel = await tcModelService.fetchDataAndBuildTCModel(

--- a/test/UIChoicesBridge/UIChoicesParser.test.ts
+++ b/test/UIChoicesBridge/UIChoicesParser.test.ts
@@ -15,8 +15,8 @@ describe('UIChoicesParser suit test', () => {
         const choicesStateHandler = new UIChoicesBridgeDtoBuilder(
             tcModelInit,
             acModelInit,
-            true)
-            .createUIChoicesBridgeDto();
+            true,
+        ).createUIChoicesBridgeDto();
 
         // Simulate User choices changes
         choicesStateHandler.UIPurposeChoices.forEach((purposeChoice) => (purposeChoice.state = true));
@@ -47,7 +47,9 @@ describe('UIChoicesParser suit test', () => {
         expect([...tcModel.purposeConsents.values()].length, '[...tcModel.purposeConsents.values()].length').to.equal(
             10,
         );
-        expect([...tcModel.vendorConsents.values()].length, '[...tcModel.vendorConsents.values()].length').to.equal(736);
+        expect([...tcModel.vendorConsents.values()].length, '[...tcModel.vendorConsents.values()].length').to.equal(
+            736,
+        );
         expect(
             [...tcModel.vendorLegitimateInterests.values()].length,
             '[...tcModel.vendorLegitimateInterests.values()].length',


### PR DESCRIPTION
Essentially we have to download the vendor-list.json only when the CMP UI will be rendered.
So, after the user gives their consent, the browser of the user doesn't download this vendor-list.json until the vendorListVersion change.

This will give a pump up in terms of performance general in the website of the publisher.

Issue code: [#66]

Note: Project docs improved.