### PR TITLE
[#74] Remove debug flag from CmpConfiguration

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@ const soloCmp = new SoloCmp(
            onConsentAds: () => {
                //Execute some logic when the consents are already present or the user has given his consent.
            },
-           debug: true 
     },
     supportedLanguages: ['it', 'en'], //Here you can specify all the languages that your CMP supports and consequently the case in which a certain language is not supported will be automatically handled and there will be a fallback to 'en'
     cmpVersion: cmpVersion,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pubtech-ai/solo-cmp",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pubtech-ai/solo-cmp",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "description": "Wrapper of IAB module that make simple to made a CMP",
   "author": "Marco Prontera <https://github.com/Marco-Prontera>",
   "license": "Apache-2.0",

--- a/src/Service/CmpConfiguration/CmpConfiguration.ts
+++ b/src/Service/CmpConfiguration/CmpConfiguration.ts
@@ -9,7 +9,6 @@ export class CmpConfiguration {
 
     private readonly _isAmp: boolean;
     private readonly _onConsentAdsCallBack: (event: ConsentReadyEvent, tcModel: TCModel) => void;
-    private readonly _debug: boolean;
 
     /**
      * Constructor.
@@ -20,7 +19,6 @@ export class CmpConfiguration {
 
         this._onConsentAdsCallBack = configuration.onConsentAds;
         this._isAmp = configuration.isAmp;
-        this._debug = configuration.debug;
 
     }
 
@@ -33,12 +31,6 @@ export class CmpConfiguration {
     get onConsentAdsCallBack(): any {
 
         return this._onConsentAdsCallBack;
-
-    }
-
-    get debug(): boolean {
-
-        return this._debug;
 
     }
 

--- a/src/Service/CmpConfiguration/ConfigurationInteface.ts
+++ b/src/Service/CmpConfiguration/ConfigurationInteface.ts
@@ -7,5 +7,4 @@ import {TCModel} from '@iabtcf/core';
 export interface ConfigurationInterface {
     isAmp: boolean;
     onConsentAds: (event: ConsentReadyEvent, tcModel: TCModel) => void;
-    debug: boolean;
 }

--- a/src/Service/CmpConfigurationProvider.ts
+++ b/src/Service/CmpConfigurationProvider.ts
@@ -35,16 +35,9 @@ export class CmpConfigurationProvider {
 
         }
 
-        if (typeof cmpConfig.debug !== 'boolean') {
-
-            throw new Error('CmpConfig, debug parameter must be a boolean.');
-
-        }
-
         const configuration: ConfigurationInterface = {
             isAmp: cmpConfig.isAmp,
             onConsentAds: cmpConfig.onConsentAds,
-            debug: cmpConfig.debug,
         };
 
         this._cmpConfiguration = new CmpConfiguration(configuration);

--- a/test/Service/CmpConfigurationProvider.test.ts
+++ b/test/Service/CmpConfigurationProvider.test.ts
@@ -8,14 +8,12 @@ describe('CmpConfigurationProvider suit test', () => {
             onConsentAds: (purposesAccepted) => {
                 purposesAccepted.includes(1);
             },
-            debug: true,
         };
 
         const cmpConfigurationProvider: CmpConfigurationProvider = new CmpConfigurationProvider(cmpConfig);
 
         const cmpConfiguration: CmpConfiguration = cmpConfigurationProvider.cmpConfiguration;
 
-        expect(cmpConfiguration.debug).to.be.true;
         expect(cmpConfiguration.isAmp).to.be.false;
         expect(cmpConfiguration.onConsentAdsCallBack).to.deep.equal(cmpConfig.onConsentAds);
     });
@@ -32,7 +30,6 @@ describe('CmpConfigurationProvider suit test', () => {
         const cmpConfig = {
             isAmp: 'false',
             onConsentAds: () => {},
-            debug: true,
         };
 
         const construction = function () {
@@ -54,19 +51,5 @@ describe('CmpConfigurationProvider suit test', () => {
         };
 
         expect(construction).to.throw('CmpConfig, onConsentAds parameter must be a function.');
-    });
-
-    it('CmpConfigurationProvider construction thrown if wrong debug parameter is provided test', () => {
-        const cmpConfig = {
-            isAmp: false,
-            onConsentAds: () => {},
-            debug: 'true',
-        };
-
-        const construction = function () {
-            new CmpConfigurationProvider(cmpConfig);
-        };
-
-        expect(construction).to.throw('CmpConfig, debug parameter must be a boolean.');
     });
 });


### PR DESCRIPTION
The goal is to remove the debug flag from CmpConfiguration because it's unused.

Issue code: [#74]