### PR TITLE
[#78] Silent failure usage of ACString

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pubtech-ai/solo-cmp",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pubtech-ai/solo-cmp",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Wrapper of IAB module that make simple to made a CMP",
   "author": "Marco Prontera <https://github.com/Marco-Prontera>",
   "license": "Apache-2.0",

--- a/src/Service/ACStringService.ts
+++ b/src/Service/ACStringService.ts
@@ -144,7 +144,7 @@ export class ACStringService {
 
         } catch (error) {
 
-            this.loggerService.error('Can\'t persist ACString to localStorage.', error);
+            this.loggerService.debug('Can\'t persist ACString to localStorage.', error);
 
         }
 
@@ -163,7 +163,7 @@ export class ACStringService {
 
         } catch (error) {
 
-            this.loggerService.error('Can\'t retrieve ACString from localStorage.', error);
+            this.loggerService.debug('Can\'t retrieve ACString from localStorage.', error);
             return `${this.acStringVersion + ACStringService.acStringIdSeparator}`;
 
         }

--- a/src/Service/CmpPreparatoryService.ts
+++ b/src/Service/CmpPreparatoryService.ts
@@ -77,7 +77,7 @@ export class CmpPreparatoryService {
                     }
 
                     // Necessary, to know if the building process must set up some options enabled or not.
-                    const firstTimeConsentRequest = tcString == '';
+                    const firstTimeConsentRequest = tcString == '' || tcString == null;
 
                     const uiChoicesBridgeDto: UIChoicesBridgeDto = new UIChoicesBridgeDtoBuilder(
                         tcModel,

--- a/src/Service/TCStringService.ts
+++ b/src/Service/TCStringService.ts
@@ -145,11 +145,7 @@ export class TCStringService {
             [...tcModel.purposeLegitimateInterests.values()].filter((purposeId) => purposeId !== 1);
         tcModel.publisherLegitimateInterests.set(purposeLegitimateInterests);
 
-        const tcString: string = TCString.encode(tcModelWithAllEnabled);
-
-        this.loggerService.debug('TCString all enabled built fixeddd: ' + tcString);
-
-        return tcString;
+        return TCString.encode(tcModelWithAllEnabled);
 
     }
 


### PR DESCRIPTION
When occurs error on retrieving ACString or persist ACString we want to make our CMP run so the user can provide its consents also if there isn't the possibility for some reason to handle the ACString. So for this, we log the errors only in debug mode.

Issue code: [#78]