### PR TITLE
[#86] Add a parameter to disable or enable the use of LegitimateInterest of IAB

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ const soloCmp = new SoloCmp(
     initialHeightAmpCmpUi: '30vh', // Amp configuration this configure the initial height of the CMP running in an AMP environment.
     enableBorderAmpCmpUi: false, // Amp configuration this configure the border of the CMP running in an AMP environment.
     skipACStringCheck: false, // This parameter, if configured to true, allows to avoid the validation code of the ACString.
+    isLegitimateInterestDisabled: false // This parameter, if configured to true, allows to skip the legitimate interest build.
 }
 );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pubtech-ai/solo-cmp",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pubtech-ai/solo-cmp",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "Wrapper of IAB module that make simple to made a CMP",
   "author": "Marco Prontera <https://github.com/Marco-Prontera>",
   "license": "Apache-2.0",

--- a/src/Dto/SoloCmpDto.ts
+++ b/src/Dto/SoloCmpDto.ts
@@ -20,4 +20,5 @@ export interface SoloCmpDto {
     initialHeightAmpCmpUi: string | null;
     enableBorderAmpCmpUi: boolean | null;
     skipACStringCheck: boolean;
+    isLegitimateInterestDisabled: boolean;
 }

--- a/src/Service/CmpPreparatoryService.ts
+++ b/src/Service/CmpPreparatoryService.ts
@@ -19,6 +19,7 @@ export class CmpPreparatoryService {
     private uiConstructor: UIConstructor;
     private eventDispatcher: EventDispatcher;
     private loggerService: LoggerService;
+    private isLegitimateInterestDisabled: boolean
 
     /**
      * Constructor.
@@ -28,6 +29,7 @@ export class CmpPreparatoryService {
      * @param {UIConstructor} uiConstructor
      * @param {EventDispatcher} eventDispatcher
      * @param {LoggerService} loggerService
+     * @param {Boolean} isLegitimateInterestDisabled
      */
     constructor(
         tcModelService: TCModelService,
@@ -35,6 +37,7 @@ export class CmpPreparatoryService {
         uiConstructor: UIConstructor,
         eventDispatcher: EventDispatcher,
         loggerService: LoggerService,
+        isLegitimateInterestDisabled: boolean,
     ) {
 
         this.tcModelService = tcModelService;
@@ -42,6 +45,7 @@ export class CmpPreparatoryService {
         this.uiConstructor = uiConstructor;
         this.eventDispatcher = eventDispatcher;
         this.loggerService = loggerService;
+        this.isLegitimateInterestDisabled = isLegitimateInterestDisabled;
 
     }
 
@@ -83,6 +87,7 @@ export class CmpPreparatoryService {
                         tcModel,
                         acModel,
                         firstTimeConsentRequest,
+                        this.isLegitimateInterestDisabled,
                     ).createUIChoicesBridgeDto();
 
                     const soloCmpDataBundle = new SoloCmpDataBundle(

--- a/src/Service/TCStringService.ts
+++ b/src/Service/TCStringService.ts
@@ -14,6 +14,7 @@ export class TCStringService {
     private readonly cmpVendorListVersion: number;
     private readonly cmpSupportedLanguageProvider: CmpSupportedLanguageProvider;
     private readonly tcStringCookieName: string;
+    private readonly isLegitimateInterestDisabled: boolean;
 
     /**
      * Constructor.
@@ -24,6 +25,7 @@ export class TCStringService {
      * @param {number} cmpVersion
      * @param {number} cmpVendorListVersion
      * @param {string} tcStringCookieName
+     * @param {boolean} isLegitimateInterestDisabled
      */
     constructor(
         cookieService: CookieService,
@@ -32,6 +34,7 @@ export class TCStringService {
         cmpVersion: number,
         cmpVendorListVersion: number,
         tcStringCookieName: string,
+        isLegitimateInterestDisabled: boolean,
     ) {
 
         if (Number.isNaN(cmpVersion)) {
@@ -60,6 +63,7 @@ export class TCStringService {
         this.cmpVersion = cmpVersion;
         this.cmpVendorListVersion = cmpVendorListVersion;
         this.tcStringCookieName = tcStringCookieName;
+        this.isLegitimateInterestDisabled = isLegitimateInterestDisabled;
 
     }
 
@@ -135,18 +139,26 @@ export class TCStringService {
      */
     public buildTCStringAllEnabled(tcModel: TCModel): string {
 
-        const tcModelWithAllEnabled: TCModel = tcModel;
-
-        tcModelWithAllEnabled.setAll();
+        tcModel.setAll();
 
         // REQUIRED UNTIL SOLVED https://github.com/InteractiveAdvertisingBureau/iabtcf-es/issues/179
         tcModel.publisherConsents.set([...tcModel.purposeConsents.values()]);
-        const purposeLegitimateInterests = [...tcModel.purposeLegitimateInterests.values()].filter(
-            (purposeId) => purposeId !== 1,
-        );
-        tcModel.publisherLegitimateInterests.set(purposeLegitimateInterests);
 
-        return TCString.encode(tcModelWithAllEnabled);
+        if (this.isLegitimateInterestDisabled) {
+
+            tcModel.unsetAllPurposeLegitimateInterests();
+            tcModel.unsetAllVendorLegitimateInterests();
+
+        } else {
+
+            const purposeLegitimateInterests = [...tcModel.purposeLegitimateInterests.values()].filter(
+                (purposeId) => purposeId !== 1,
+            );
+            tcModel.publisherLegitimateInterests.set(purposeLegitimateInterests);
+
+        }
+
+        return TCString.encode(tcModel);
 
     }
 

--- a/src/SoloCmp.ts
+++ b/src/SoloCmp.ts
@@ -1,9 +1,9 @@
-import {SoloCmpDto} from './Dto';
 import {GVL} from '@iabtcf/core';
 import {IContainer} from 'bottlejs';
 import DependencyInjectionManager from './DependencyInjection/DependencyInjectionManager';
 import {EventDispatcher} from './EventDispatcher';
 import {UIConstructor} from './UIConstructor';
+import {SoloCmpDto} from './Dto';
 
 import {
     AmpSubscriber,
@@ -52,6 +52,7 @@ export class SoloCmp {
     private readonly initialHeightAmpCmpUi: string | null;
     private readonly enableBorderAmpCmpUi: boolean | null = null;
     private readonly skipACStringCheck: boolean;
+    private readonly isLegitimateInterestDisabled: boolean;
 
     /**
      * Constructor.
@@ -76,6 +77,7 @@ export class SoloCmp {
         this.initialHeightAmpCmpUi = soloCmpDto.initialHeightAmpCmpUi;
         this.enableBorderAmpCmpUi = soloCmpDto.enableBorderAmpCmpUi;
         this.skipACStringCheck = soloCmpDto.skipACStringCheck;
+        this.isLegitimateInterestDisabled = soloCmpDto.isLegitimateInterestDisabled;
 
         this.registerServices();
         this.registerSubscribers();

--- a/src/SoloCmp.ts
+++ b/src/SoloCmp.ts
@@ -119,6 +119,7 @@ export class SoloCmp {
                     this.cmpVersion,
                     this.cmpVendorListVersion,
                     this.tcStringCookieName,
+                    this.isLegitimateInterestDisabled,
                 );
 
             })

--- a/src/SoloCmp.ts
+++ b/src/SoloCmp.ts
@@ -218,6 +218,7 @@ export class SoloCmp {
                     this.uiConstructor,
                     container[EventDispatcher.getClassName()],
                     container[LoggerService.getClassName()],
+                    this.isLegitimateInterestDisabled,
                 );
 
             })

--- a/src/UIChoicesBridge/UIChoicesBridgeDtoBuilder.ts
+++ b/src/UIChoicesBridge/UIChoicesBridgeDtoBuilder.ts
@@ -31,16 +31,28 @@ export class UIChoicesBridgeDtoBuilder {
      * @param {TCModel} tcModel
      * @param {ACModel} acModel
      * @param {boolean} firstTimeConsentRequest
+     * @param {boolean} isLegitimateInterestDisabled
      * @private
      */
-    constructor(tcModel: TCModel, acModel: ACModel, firstTimeConsentRequest: boolean) {
+    constructor(
+        tcModel: TCModel,
+        acModel: ACModel,
+        firstTimeConsentRequest: boolean,
+        isLegitimateInterestDisabled: boolean,
+    ) {
 
         this.firstTimeConsentRequest = firstTimeConsentRequest;
 
         this.buildUIPurposeChoices(tcModel);
         this.buildUISpecialFeatureOptInsChoices(tcModel);
         this.buildUIVendorChoices(tcModel);
-        this.buildUILegitimateInterestsChoices(tcModel);
+
+        if (!isLegitimateInterestDisabled) {
+
+            this.buildUILegitimateInterestsChoices(tcModel);
+
+        }
+
         this.buildUIGoogleVendorOptions(acModel);
 
     }

--- a/src/UIChoicesBridge/UIChoicesBridgeDtoBuilder.ts
+++ b/src/UIChoicesBridge/UIChoicesBridgeDtoBuilder.ts
@@ -72,27 +72,7 @@ export class UIChoicesBridgeDtoBuilder {
      */
     private buildUIPurposeChoices(tcModel: TCModel): void {
 
-        const purposes = tcModel.gvl.purposes;
-
-        const purposesIds: string[] = Object.keys(purposes);
-
-        const purposeOptions: PurposeOption[] = [];
-
-        purposesIds.forEach((purposeId) => {
-
-            const purpose: Purpose = purposes[purposeId];
-            purposeOptions.push({
-                state: tcModel.purposeConsents.has(purpose.id),
-                id: Number(purpose.id),
-                title: purpose.name,
-                description: purpose.description,
-                legalDescription: purpose.descriptionLegal,
-                vendors: tcModel.gvl.getVendorsWithConsentPurpose(purpose.id),
-            });
-
-        });
-
-        this._UIPurposeChoices = purposeOptions;
+        this._UIPurposeChoices = this.buildUIConsentChoices(tcModel, tcModel.gvl.purposes, 'purposeConsents', 'getVendorsWithConsentPurpose');
 
     }
 
@@ -105,27 +85,47 @@ export class UIChoicesBridgeDtoBuilder {
      */
     private buildUISpecialFeatureOptInsChoices(tcModel: TCModel): void {
 
-        const specialFeatures = tcModel.gvl.specialFeatures;
+        this._UISpecialFeatureOptInsChoices = this.buildUIConsentChoices(tcModel, tcModel.gvl.specialFeatures, 'specialFeatureOptins', 'getVendorsWithSpecialFeature');
 
-        const specialFeaturesIds: string[] = Object.keys(specialFeatures);
+    }
 
-        const specialFeaturesOptions: SpecialFeatureOption[] = [];
+    /**
+     * Build UI Consent choices.
+     *
+     * @param {TCModel} tcModel
+     * @param {IntMap<Purpose> | IntMap<Feature>}tcfChoices
+     * @param {string} tcfModelStateChoices
+     * @param {string} tcfGVLMethod
+     * @private
+     *
+     * @return {PurposeOption[] | SpecialFeatureOption[]}
+     */
+    private buildUIConsentChoices(
+        tcModel,
+        tcfChoices,
+        tcfModelStateChoices,
+        tcfGVLMethod,
+    ): PurposeOption[] | SpecialFeatureOption[] {
 
-        specialFeaturesIds.forEach((specialFeaturesId) => {
+        const choicesIds: string[] = Object.keys(tcfChoices);
 
-            const specialFeature: Feature = specialFeatures[specialFeaturesId];
-            specialFeaturesOptions.push({
-                state: tcModel.specialFeatureOptins.has(specialFeature.id),
-                id: Number(specialFeature.id),
-                title: specialFeature.name,
-                description: specialFeature.description,
-                legalDescription: specialFeature.descriptionLegal,
-                vendors: tcModel.gvl.getVendorsWithSpecialFeature(specialFeature.id),
+        const consentOptions: PurposeOption[] | SpecialFeatureOption[] = [];
+
+        choicesIds.forEach((choiceId) => {
+
+            const choice: Purpose | Feature = tcfChoices[choiceId];
+            consentOptions.push({
+                state: tcModel[tcfModelStateChoices].has(choice.id),
+                id: Number(choice.id),
+                title: choice.name,
+                description: choice.description,
+                legalDescription: choice.descriptionLegal,
+                vendors: tcModel.gvl[tcfGVLMethod](choice.id),
             });
 
         });
 
-        this._UISpecialFeatureOptInsChoices = specialFeaturesOptions;
+        return consentOptions;
 
     }
 
@@ -142,47 +142,7 @@ export class UIChoicesBridgeDtoBuilder {
 
         const vendorIds: string[] = Object.keys(vendors);
 
-        const vendorOption: VendorOption[] = [];
-
-        vendorIds.forEach((vendorId) => {
-
-            const vendor: Vendor = vendors[vendorId];
-
-            // IAB use null instead of NaN, it's a bad design, so we fix it!
-            let cookieMaxAgeSeconds = NaN;
-
-            if (typeof vendor.cookieMaxAgeSeconds === 'number' && !isNaN(vendor.cookieMaxAgeSeconds)) {
-
-                cookieMaxAgeSeconds = Number(vendor.cookieMaxAgeSeconds);
-
-            }
-
-            // Set vendors default to true, purposes lead vendors
-            const state = this.firstTimeConsentRequest ? true : tcModel.vendorConsents.has(vendor.id);
-
-            vendorOption.push({
-                state: state,
-                features: UIChoicesBridgeDtoBuilder.buildVendorFeatures(vendor.features, tcModel.gvl.features),
-                flexiblePurposes: vendor.flexiblePurposes,
-                id: Number(vendor.id),
-                legIntPurposes: vendor.legIntPurposes,
-                name: vendor.name,
-                policyUrl: vendor.policyUrl,
-                cookieMaxAgeSeconds: cookieMaxAgeSeconds,
-                purposes: UIChoicesBridgeDtoBuilder.buildVendorPurposes(vendor.purposes, tcModel.gvl.purposes),
-                specialFeatures: UIChoicesBridgeDtoBuilder.buildVendorFeatures(
-                    vendor.specialFeatures,
-                    tcModel.gvl.specialFeatures,
-                ),
-                specialPurposes: UIChoicesBridgeDtoBuilder.buildVendorPurposes(
-                    vendor.specialPurposes,
-                    tcModel.gvl.specialPurposes,
-                ),
-            });
-
-        });
-
-        this._UIVendorChoices = vendorOption;
+        this._UIVendorChoices = this.buildUIConsentVendorChoices(tcModel, vendorIds, vendors, 'vendorConsents');
 
     }
 
@@ -199,6 +159,88 @@ export class UIChoicesBridgeDtoBuilder {
         const allVendorsWithLegitimateInterests = this.buildLegitimateInterestsPurposeOptions(tcModel);
 
         this.buildLegitimateInterestsVendorOptions(allVendorsWithLegitimateInterests, tcModel);
+
+    }
+
+    /**
+     * Build the UILegitimateInterestsVendorChoices with the provided TCModel and set
+     * status in base of the consent enabled in it.
+     *
+     * @param {array} allVendorsWithLegitimateInterests
+     * @param {TCModel} tcModel
+     * @private
+     */
+    private buildLegitimateInterestsVendorOptions(
+        allVendorsWithLegitimateInterests: IntMap<Vendor>,
+        tcModel: TCModel,
+    ): void {
+
+        const vendorIds = Object.keys(allVendorsWithLegitimateInterests);
+
+        this._UILegitimateInterestsVendorChoices = this.buildUIConsentVendorChoices(tcModel, vendorIds, allVendorsWithLegitimateInterests, 'vendorLegitimateInterests');
+
+    }
+
+    /**
+     * Build UI Consent for Vendor Choices.
+     *
+     * @param {TCModel} tcModel
+     * @param {string[]} vendorIds
+     * @param {IntMap<Vendor>} allVendorsWithLegitimateInterests
+     * @param {string} tcfModelStateChoices
+     * @private
+     *
+     * @return {VendorOption[]}
+     */
+    private buildUIConsentVendorChoices(
+        tcModel: TCModel,
+        vendorIds: string[],
+        allVendorsWithLegitimateInterests: IntMap<Vendor>,
+        tcfModelStateChoices: string): VendorOption[] {
+
+        const consentVendorOptions: VendorOption[] = [];
+
+        vendorIds.forEach((vendorId) => {
+
+            const vendor: Vendor = allVendorsWithLegitimateInterests[vendorId];
+
+            // IAB use null instead of NaN, it's a bad design, so we fix it!
+            let cookieMaxAgeSeconds = NaN;
+
+            if (typeof vendor.cookieMaxAgeSeconds === 'number' && !isNaN(vendor.cookieMaxAgeSeconds)) {
+
+                cookieMaxAgeSeconds = Number(vendor.cookieMaxAgeSeconds);
+
+            }
+
+            // Legitimate interest choices are opt-out, so the default is true
+            const state = this.firstTimeConsentRequest ? true : tcModel[tcfModelStateChoices].has(vendor.id);
+
+            consentVendorOptions.push({
+                state: state,
+                features: UIChoicesBridgeDtoBuilder
+                    .buildVendorPurposesOrVendorFeatures(vendor.features, tcModel.gvl.features),
+                flexiblePurposes: vendor.flexiblePurposes,
+                id: Number(vendor.id),
+                legIntPurposes: vendor.legIntPurposes,
+                name: vendor.name,
+                policyUrl: vendor.policyUrl,
+                cookieMaxAgeSeconds: cookieMaxAgeSeconds,
+                purposes: UIChoicesBridgeDtoBuilder
+                    .buildVendorPurposesOrVendorFeatures(vendor.purposes, tcModel.gvl.purposes),
+                specialFeatures: UIChoicesBridgeDtoBuilder.buildVendorPurposesOrVendorFeatures(
+                    vendor.specialFeatures,
+                    tcModel.gvl.specialFeatures,
+                ),
+                specialPurposes: UIChoicesBridgeDtoBuilder.buildVendorPurposesOrVendorFeatures(
+                    vendor.specialPurposes,
+                    tcModel.gvl.specialPurposes,
+                ),
+            });
+
+        });
+
+        return consentVendorOptions;
 
     }
 
@@ -253,114 +295,29 @@ export class UIChoicesBridgeDtoBuilder {
     }
 
     /**
-     * Build the UILegitimateInterestsVendorChoices with the provided TCModel and set
-     * status in base of the consent enabled in it.
-     *
-     * @param {array} allVendorsWithLegitimateInterests
-     * @param {TCModel} tcModel
-     * @private
-     */
-    private buildLegitimateInterestsVendorOptions(
-        allVendorsWithLegitimateInterests: IntMap<Vendor>,
-        tcModel: TCModel,
-    ): void {
-
-        const legitimateInterestsVendorOption: VendorOption[] = [];
-
-        const vendorIds = Object.keys(allVendorsWithLegitimateInterests);
-
-        vendorIds.forEach((vendorId) => {
-
-            const vendor: Vendor = allVendorsWithLegitimateInterests[vendorId];
-
-            // IAB use null instead of NaN, it's a bad design, so we fix it!
-            let cookieMaxAgeSeconds = NaN;
-
-            if (typeof vendor.cookieMaxAgeSeconds === 'number' && !isNaN(vendor.cookieMaxAgeSeconds)) {
-
-                cookieMaxAgeSeconds = Number(vendor.cookieMaxAgeSeconds);
-
-            }
-
-            // Legitimate interest choices are opt-out, so the default is true
-            const state = this.firstTimeConsentRequest ? true : tcModel.vendorLegitimateInterests.has(vendor.id);
-
-            legitimateInterestsVendorOption.push({
-                state: state,
-                features: UIChoicesBridgeDtoBuilder.buildVendorFeatures(vendor.features, tcModel.gvl.features),
-                flexiblePurposes: vendor.flexiblePurposes,
-                id: Number(vendor.id),
-                legIntPurposes: vendor.legIntPurposes,
-                name: vendor.name,
-                policyUrl: vendor.policyUrl,
-                cookieMaxAgeSeconds: cookieMaxAgeSeconds,
-                purposes: UIChoicesBridgeDtoBuilder.buildVendorPurposes(vendor.purposes, tcModel.gvl.purposes),
-                specialFeatures: UIChoicesBridgeDtoBuilder.buildVendorFeatures(
-                    vendor.specialFeatures,
-                    tcModel.gvl.specialFeatures,
-                ),
-                specialPurposes: UIChoicesBridgeDtoBuilder.buildVendorPurposes(
-                    vendor.specialPurposes,
-                    tcModel.gvl.specialPurposes,
-                ),
-            });
-
-        });
-
-        this._UILegitimateInterestsVendorChoices = legitimateInterestsVendorOption;
-
-    }
-
-    /**
      * Build the vendor purpose entity for every purposes provided.
      *
-     * @param {number[]} purposeIds
-     * @param {IntMap<Purpose>} purposesBases
+     * @param {number[]} purposeOrFeatureIds
+     * @param {IntMap<Purpose>|IntMap<Feature>} purposesOrFeatureBases
      * @private
      *
-     * @return {VendorPurpose[]}
+     * @return {VendorPurpose[]|VendorFeature[]}
      */
-    private static buildVendorPurposes(purposeIds: number[], purposesBases: IntMap<Purpose>): VendorPurpose[] {
+    private static buildVendorPurposesOrVendorFeatures(
+        purposeOrFeatureIds: number[],
+        purposesOrFeatureBases: IntMap<Purpose> | IntMap<Feature>,
+    ): VendorPurpose[] | VendorFeature[] {
 
-        const result: VendorPurpose[] = [];
+        const result: VendorPurpose[] | VendorFeature[] = [];
 
-        purposeIds.forEach((purposeId) => {
+        purposeOrFeatureIds.forEach((purposeId) => {
 
-            const purpose = purposesBases[purposeId];
+            const purpose = purposesOrFeatureBases[purposeId];
             result.push({
                 id: Number(purpose.id),
                 name: purpose.name,
                 description: purpose.description,
                 descriptionLegal: purpose.descriptionLegal,
-            });
-
-        });
-
-        return result;
-
-    }
-
-    /**
-     * Build the vendor feature entity for every feature provided.
-     *
-     * @param {number[]} featureIds
-     * @param {IntMap<Feature>} featuresBases
-     * @private
-     *
-     * @return {VendorPurpose[]}
-     */
-    private static buildVendorFeatures(featureIds: number[], featuresBases: IntMap<Feature>): VendorFeature[] {
-
-        const result: VendorFeature[] = [];
-
-        featureIds.forEach((featureId) => {
-
-            const feature = featuresBases[featureId];
-            result.push({
-                id: Number(feature.id),
-                name: feature.name,
-                description: feature.description,
-                descriptionLegal: feature.descriptionLegal,
             });
 
         });

--- a/test/Service/TCStringService.test.ts
+++ b/test/Service/TCStringService.test.ts
@@ -185,6 +185,7 @@ describe('TCStringService suit test', () => {
             1,
             1,
             'solo-cmp-tc-string',
+            false,
         );
 
         const tcStringWillAllConsentsEnabled: string = tcStringService.buildTCStringAllEnabled(tcModel);
@@ -194,6 +195,37 @@ describe('TCStringService suit test', () => {
         expect(tcModelWithAllEnabled.purposeLegitimateInterests.size).to.equal(9);
         expect(tcModelWithAllEnabled.purposeConsents.size).to.equal(10);
         expect(tcModelWithAllEnabled.vendorLegitimateInterests.size).to.equal(209);
+        expect(tcModelWithAllEnabled.vendorConsents.size).to.equal(467);
+
+    });
+
+    it('TCStringService build tcString with all consents enabled without legitimate interest test', () => {
+
+        const tcString = TCString.encode(getTCModel());
+
+        const tcModel: TCModel = TCString.decode(tcString);
+
+        tcModel.gvl = new GVL(require('@iabtcf/testing/lib/vendorlist/vendor-list.json'));
+
+        const cmpSupportedLanguageProvider = new CmpSupportedLanguageProvider(['it', 'fr', 'en'], 'it');
+
+        const tcStringService = new TCStringService(
+            cookieService,
+            loggerService,
+            cmpSupportedLanguageProvider,
+            1,
+            1,
+            'solo-cmp-tc-string',
+            true,
+        );
+
+        const tcStringWillAllConsentsEnabled: string = tcStringService.buildTCStringAllEnabled(tcModel);
+
+        const tcModelWithAllEnabled: TCModel = TCString.decode(tcStringWillAllConsentsEnabled);
+
+        expect(tcModelWithAllEnabled.purposeLegitimateInterests.size).to.equal(0);
+        expect(tcModelWithAllEnabled.purposeConsents.size).to.equal(10);
+        expect(tcModelWithAllEnabled.vendorLegitimateInterests.size).to.equal(0);
         expect(tcModelWithAllEnabled.vendorConsents.size).to.equal(467);
 
     });

--- a/test/UIChoicesBridge/UIChoicesBridgeDtoBuilder.test.ts
+++ b/test/UIChoicesBridge/UIChoicesBridgeDtoBuilder.test.ts
@@ -1,12 +1,13 @@
 import {expect} from 'chai';
 import {GVL, TCModel} from '@iabtcf/core';
-import vendorList from '../Fixtures/vendor-list';
 import {ACModel} from '../../src/Entity';
 import {UIChoicesBridgeDto, UIChoicesBridgeDtoBuilder} from '../../src/UIChoicesBridge';
 
+// @ts-ignore
+import vendorList from '../Fixtures/vendor-list';
+
 const getTCModelByFixture = function() {
 
-    // @ts-ignore
     const gvl = new GVL(vendorList);
 
     const tcModel = new TCModel(gvl);
@@ -46,6 +47,8 @@ describe('UIChoicesStateHandler suit test', () => {
         const uiChoicesBridgeDto: UIChoicesBridgeDto = new UIChoicesBridgeDtoBuilder(
             getTCModelByFixture(),
             getACModelByFixture(),
+            false,
+            false,
         ).createUIChoicesBridgeDto();
 
         const tcModel = getTCModelByFixture();
@@ -77,6 +80,65 @@ describe('UIChoicesStateHandler suit test', () => {
         expect(countLegIntVendorsChoicesEnabled, 'countLegIntVendorsChoicesEnabled').to.equal(
             [...tcModel.vendorLegitimateInterests.values()].length,
         );
+
+        // Check UIVendorChoices
+        const countVendorsChoicesEnabled = uiChoicesBridgeDto.UIVendorChoices.filter((choice) => choice.state).length;
+        expect(countVendorsChoicesEnabled, 'countVendorsChoicesEnabled').to.equal(
+            [...tcModel.vendorConsents.values()].length,
+        );
+
+        // Check UIPurposeChoices
+        const countPurposeChoicesEnabled = uiChoicesBridgeDto.UIPurposeChoices.filter((choice) => choice.state).length;
+        expect(countPurposeChoicesEnabled, 'countPurposeChoicesEnabled').to.equal(
+            [...tcModel.purposeConsents.values()].length,
+        );
+
+        // Check UISpecialFeatureChoices
+        const countSpecialFeatureChoicesEnabled = uiChoicesBridgeDto.UISpecialFeatureChoices.filter(
+            (choice) => choice.state,
+        ).length;
+        expect(countSpecialFeatureChoicesEnabled, 'countSpecialFeatureChoicesEnabled').to.equal(0);
+
+        // Check UIGoogleVendorOptions
+        const countGoogleVendorOptionsChoicesEnabled = uiChoicesBridgeDto.UIGoogleVendorOptions.filter(
+            (choice) => choice.state,
+        ).length;
+        expect(countGoogleVendorOptionsChoicesEnabled, 'countGoogleVendorOptionsChoicesEnabled').to.equal(
+            acModel.googleVendorOptions.filter((option) => option.state).length,
+        );
+
+    });
+
+    it('UIChoicesStateHandler test entity built without legitimate interest test', () => {
+
+        const uiChoicesBridgeDto: UIChoicesBridgeDto = new UIChoicesBridgeDtoBuilder(
+            getTCModelByFixture(),
+            getACModelByFixture(),
+            false,
+            true,
+        ).createUIChoicesBridgeDto();
+
+        const tcModel = getTCModelByFixture();
+        const acModel = getACModelByFixture();
+
+        expect(uiChoicesBridgeDto.UIPurposeChoices.length, 'choicesStateHandler.UIPurposeChoices.length').to.equal(
+            Object.keys(tcModel.gvl.purposes).length,
+        );
+        expect(uiChoicesBridgeDto.UIVendorChoices.length, 'choicesStateHandler.UIVendorChoices.length').to.equal(
+            Object.keys(tcModel.gvl.vendors).length,
+        );
+        expect(
+            uiChoicesBridgeDto.UIGoogleVendorOptions.length,
+            'choicesStateHandler.UIGoogleVendorOptions.length',
+        ).to.equal(2);
+
+        // Check UILegitimateInterestsPurposeChoices
+        const countLegIntPurposeChoicesEnabled = uiChoicesBridgeDto.UILegitimateInterestsPurposeChoices.length;
+        expect(countLegIntPurposeChoicesEnabled, 'countLegIntPurposeChoicesEnabled').to.equal(0);
+
+        // Check UILegitimateInterestsVendorChoices
+        const countLegIntVendorsChoicesEnabled = uiChoicesBridgeDto.UILegitimateInterestsVendorChoices.length;
+        expect(countLegIntVendorsChoicesEnabled, 'countLegIntVendorsChoicesEnabled').to.equal(0);
 
         // Check UIVendorChoices
         const countVendorsChoicesEnabled = uiChoicesBridgeDto.UIVendorChoices.filter((choice) => choice.state).length;


### PR DESCRIPTION
The goal of this PR:
- Add a parameter to disable or enable the use of legitimate interest of IAB

Issue code [#86]

The implemented solution directly skips the creation of any data structure to store information for legitimate interest. 
So the device does not need to calculate something that is not required.

Note: 
- Refactoring applied to ChoiceBuilder