### PR TITLE
[#92] When the isAmp parameter is true the init function must render the CMP

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pubtech-ai/solo-cmp",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pubtech-ai/solo-cmp",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@iabtcf/cmpapi": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pubtech-ai/solo-cmp",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Wrapper of IAB module that make simple to made a CMP",
   "author": "Marco Prontera <https://github.com/Marco-Prontera>",
   "license": "Apache-2.0",

--- a/src/SoloCmp.ts
+++ b/src/SoloCmp.ts
@@ -304,6 +304,7 @@ export class SoloCmp {
 
             if (this.isAmp) {
 
+                // We always need to render the CMP when the environment is AMP
                 eventDispatcher.dispatch(new OpenCmpUIEvent(tcString as string, acString as string));
 
             } else {

--- a/src/SoloCmp.ts
+++ b/src/SoloCmp.ts
@@ -295,13 +295,26 @@ export class SoloCmp {
 
         const eventDispatcher = this._DependencyInjectionManager.getService(EventDispatcher.getClassName());
 
-        if (tcStringService.isValidTCString(tcString) && acStringService.isValidACString(acString) && (typeof additionalValidationCallback == 'function' ? additionalValidationCallback() : true)) {
+        const isAdditionalValidationCallbackValid: boolean = (typeof additionalValidationCallback == 'function' ? additionalValidationCallback() : true);
 
-            const consentReadyEvent = new ConsentReadyEvent(tcString as string, acString as string);
+        if (
+            tcStringService.isValidTCString(tcString) &&
+            acStringService.isValidACString(acString) &&
+            isAdditionalValidationCallbackValid) {
 
-            eventDispatcher.dispatch(consentReadyEvent);
+            if (this.isAmp) {
 
-            this.uiConstructor.buildOpenCmpButtonAndRender();
+                eventDispatcher.dispatch(new OpenCmpUIEvent(tcString as string, acString as string));
+
+            } else {
+
+                const consentReadyEvent = new ConsentReadyEvent(tcString as string, acString as string);
+
+                eventDispatcher.dispatch(consentReadyEvent);
+
+                this.uiConstructor.buildOpenCmpButtonAndRender();
+
+            }
 
         } else {
 

--- a/src/SoloCmp.ts
+++ b/src/SoloCmp.ts
@@ -304,7 +304,11 @@ export class SoloCmp {
 
             if (this.isAmp) {
 
-                // We always need to render the CMP when the environment is AMP
+                /**
+                 * We always need to render the CMP when the environment is AMP,
+                 * because the CMP will be executed only when AMP require consent
+                 * or the user want to change their privacy settings.
+                 */
                 eventDispatcher.dispatch(new OpenCmpUIEvent(tcString as string, acString as string));
 
             } else {


### PR DESCRIPTION
When the isAmp parameter is true the init function must render the CMP.
This is required because in the AMP environment there is not an event that indicates to open the CMP so, we can check the isAmp parameter to see if the render of the UI is.

Close #92 