### PR TITLE
[#96] Implement LazyVendorListVersionUpdate feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ const soloCmp = new SoloCmp(
     enableBorderAmpCmpUi: false, // Amp configuration this configure the border of the CMP running in an AMP environment.
     skipACStringCheck: false, // This parameter, if configured to true, allows to avoid the validation code of the ACString.
     isLegitimateInterestDisabled: false, // This parameter, if configured to true, allows to skip the legitimate interest build.
-    expireTCStringInDays: 365, // Provide for how much days the TCString should be valid.
+    expireTCStringInDays: 180, // Provide for how much days the TCString should be valid.
     purposeIdsForPartialCheck: [], // Here you can provide an array of purpose ids that the validation logic used to check if the consent is partial when these purpose ids are not enabled.
     expirationDaysForPartialConsents: null // This parameter, if configured with a Number, allows the preventive expiration of the tcString when purpose 1 is not enabled.
 }

--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ const soloCmp = new SoloCmp(
     enableBorderAmpCmpUi: false, // Amp configuration this configure the border of the CMP running in an AMP environment.
     skipACStringCheck: false, // This parameter, if configured to true, allows to avoid the validation code of the ACString.
     isLegitimateInterestDisabled: false, // This parameter, if configured to true, allows to skip the legitimate interest build.
+    expireTCStringInDays: 365, // Provide for how much days the TCString should be valid.
+    purposeIdsForPartialCheck: [], // Here you can provide an array of purpose ids that the validation logic used to check if the consent is partial when these purpose ids are not enabled.
     expirationDaysForPartialConsents: null // This parameter, if configured with a Number, allows the preventive expiration of the tcString when purpose 1 is not enabled.
 }
 );

--- a/src/Dto/SoloCmpDto.ts
+++ b/src/Dto/SoloCmpDto.ts
@@ -24,5 +24,7 @@ export interface SoloCmpDto {
     enableBorderAmpCmpUi: boolean | null;
     skipACStringCheck: boolean;
     isLegitimateInterestDisabled: boolean;
+    expireTCStringInDays: number;
+    purposeIdsForPartialCheck: number[];
     expirationDaysForPartialConsents: number | null;
 }

--- a/src/Service/TCStringService.ts
+++ b/src/Service/TCStringService.ts
@@ -8,14 +8,14 @@ import {CmpSupportedLanguageProvider} from './CmpSupportedLanguageProvider';
  */
 export class TCStringService {
 
-    private static readonly expireTCStringInDays = 180;
-
     private cookieService: CookieService;
     private loggerService: LoggerService;
     private readonly cmpVersion: number;
     private readonly cmpVendorListVersion: number;
     private readonly cmpSupportedLanguageProvider: CmpSupportedLanguageProvider;
     private readonly tcStringCookieName: string;
+    private readonly expireTCStringInDays: number;
+    private readonly purposeIdsForPartialCheck: number[];
     private readonly expirationDaysForPartialConsents: number | null;
 
     /**
@@ -27,6 +27,8 @@ export class TCStringService {
      * @param {number} cmpVersion
      * @param {number} cmpVendorListVersion
      * @param {string} tcStringCookieName
+     * @param {number} expireTCStringInDays
+     * @param {number[]} purposeIdsForPartialCheck
      * @param {number|null} expirationDaysForPartialConsents
      */
     constructor(
@@ -36,26 +38,26 @@ export class TCStringService {
         cmpVersion: number,
         cmpVendorListVersion: number,
         tcStringCookieName: string,
+        expireTCStringInDays = 365,
+        purposeIdsForPartialCheck: number[] = [],
         expirationDaysForPartialConsents: number | null = null,
     ) {
 
-        if (isNaN(cmpVersion)) {
+        if (isNaN(cmpVersion) || typeof cmpVersion == 'object') {
 
-            throw new Error('TCStringService, cmpVersion parameter must be a valid number.');
+            throw new Error('TCStringService.cmpVersion must be a number.');
 
         }
 
-        if (isNaN(cmpVendorListVersion)) {
+        if (isNaN(cmpVendorListVersion) || typeof cmpVersion == 'object') {
 
-            throw new Error('TCStringService, cmpVendorListVersion parameter must be a valid number.');
+            throw new Error('TCStringService.cmpVendorListVersion must be a number.');
 
         }
 
         if (tcStringCookieName.length === 0) {
 
-            throw new Error(
-                'TCStringService, tcStringCookieName parameter must be a string with a length greater than zero.',
-            );
+            throw new Error('TCStringService.tcStringCookieName must be a not empty string.');
 
         }
 
@@ -65,6 +67,8 @@ export class TCStringService {
         this.cmpVersion = Number(cmpVersion);
         this.cmpVendorListVersion = Number(cmpVendorListVersion);
         this.tcStringCookieName = tcStringCookieName;
+        this.expireTCStringInDays = Number(expireTCStringInDays);
+        this.purposeIdsForPartialCheck = purposeIdsForPartialCheck;
         this.expirationDaysForPartialConsents = expirationDaysForPartialConsents;
 
     }
@@ -76,7 +80,7 @@ export class TCStringService {
      */
     public persistTCString(tcString: string): void {
 
-        this.cookieService.setCookie(this.tcStringCookieName, tcString, TCStringService.expireTCStringInDays);
+        this.cookieService.setCookie(this.tcStringCookieName, tcString, this.expireTCStringInDays);
 
     }
 
@@ -123,7 +127,7 @@ export class TCStringService {
 
         if (tcString.length > 0) {
 
-            this.loggerService.debug('TCString built: ' + tcString);
+            this.loggerService.debug('TCString.buildTCString: ' + tcString);
 
         }
 
@@ -151,17 +155,23 @@ export class TCStringService {
 
         } catch (e) {
 
-            this.loggerService.debug(`Checking if TCString is valid: the tcstring is not decodable.`);
+            this.loggerService.debug(`TCStringService.isValidTCString: not decodable.`);
 
             return false;
 
         }
 
+        const isPartialConsent = this.purposeIdsForPartialCheck.filter((purposeId) => {
+
+            return !tcModel.purposeConsents.has(Number(purposeId));
+
+        }).length != 0;
+
         let isExpirationValid = true;
 
         if (this.expirationDaysForPartialConsents != null && !isNaN(this.expirationDaysForPartialConsents)) {
 
-            if (!tcModel.purposeConsents.has(1) && tcModel.created instanceof Date) {
+            if (isPartialConsent && tcModel.created instanceof Date) {
 
                 const tcStringDate = new Date(tcModel.created.getTime());
                 tcStringDate.setDate(tcStringDate.getDate() + Number(this.expirationDaysForPartialConsents));
@@ -171,12 +181,14 @@ export class TCStringService {
 
         }
 
-        const cmpVersionCheck: boolean = tcModel.cmpVersion === this.cmpVersion;
-        const cmpVendorListVersionCheck: boolean = tcModel.vendorListVersion === this.cmpVendorListVersion;
+        const cmpVendorListVersionCheck = isPartialConsent || this.purposeIdsForPartialCheck.length == 0 ?
+            tcModel.vendorListVersion === this.cmpVendorListVersion : true;
 
         const userLanguage: string = this.cmpSupportedLanguageProvider.getUserLanguage();
 
         let localeCheck = true;
+
+        const cmpVersionCheck: boolean = tcModel.cmpVersion === this.cmpVersion;
 
         if (this.cmpSupportedLanguageProvider.getCmpSupportedLanguages().includes(userLanguage)) {
 
@@ -185,11 +197,11 @@ export class TCStringService {
         }
 
         this.loggerService.debug(
-            `Checking if TCString is valid: 
-            localeCheck: ${localeCheck} | 
-            cmpVersionCheck: ${cmpVersionCheck} | 
-            cmpVendorListVersionCheck ${cmpVendorListVersionCheck} |
-            isExpirationValid ${isExpirationValid}`,
+            `TCStringService.isValidTCString: 
+            locale: ${localeCheck} | 
+            cmpVersion: ${cmpVersionCheck} | 
+            cmpVendorListVersion: ${cmpVendorListVersionCheck} |
+            isExpirationValid: ${isExpirationValid}`,
         );
 
         return localeCheck && cmpVersionCheck && cmpVendorListVersionCheck && isExpirationValid;

--- a/src/Service/TCStringService.ts
+++ b/src/Service/TCStringService.ts
@@ -38,7 +38,7 @@ export class TCStringService {
         cmpVersion: number,
         cmpVendorListVersion: number,
         tcStringCookieName: string,
-        expireTCStringInDays = 365,
+        expireTCStringInDays = 180,
         purposeIdsForPartialCheck: number[] = [],
         expirationDaysForPartialConsents: number | null = null,
     ) {

--- a/src/SoloCmp.ts
+++ b/src/SoloCmp.ts
@@ -53,6 +53,8 @@ export class SoloCmp {
     private readonly enableBorderAmpCmpUi: boolean | null = null;
     private readonly skipACStringCheck: boolean;
     private readonly isLegitimateInterestDisabled: boolean;
+    private readonly expireTCStringInDays: number;
+    private readonly purposeIdsForPartialCheck: number[];
     private readonly expirationDaysForPartialConsents: number | null;
 
     /**
@@ -80,6 +82,8 @@ export class SoloCmp {
         this.enableBorderAmpCmpUi = soloCmpDto.enableBorderAmpCmpUi;
         this.skipACStringCheck = soloCmpDto.skipACStringCheck;
         this.isLegitimateInterestDisabled = soloCmpDto.isLegitimateInterestDisabled;
+        this.expireTCStringInDays = soloCmpDto.expireTCStringInDays;
+        this.purposeIdsForPartialCheck = soloCmpDto.purposeIdsForPartialCheck;
         this.expirationDaysForPartialConsents = soloCmpDto.expirationDaysForPartialConsents;
 
         this.registerServices();
@@ -117,6 +121,8 @@ export class SoloCmp {
                     this.cmpVersion,
                     this.cmpVendorListVersion,
                     this.tcStringCookieName,
+                    this.expireTCStringInDays,
+                    this.purposeIdsForPartialCheck,
                     this.expirationDaysForPartialConsents,
                 );
 

--- a/test/Service/TCStringService.test.ts
+++ b/test/Service/TCStringService.test.ts
@@ -51,7 +51,7 @@ describe('TCStringService suit test', () => {
 
         };
 
-        expect(construction).to.throw('TCStringService, cmpVersion parameter must be a valid number.');
+        expect(construction).to.throw('TCStringService.cmpVersion must be a number.');
 
     });
 
@@ -72,7 +72,7 @@ describe('TCStringService suit test', () => {
 
         };
 
-        expect(construction).to.throw('TCStringService, cmpVendorListVersion parameter must be a valid number.');
+        expect(construction).to.throw('TCStringService.cmpVendorListVersion must be a number.');
 
     });
 
@@ -87,7 +87,7 @@ describe('TCStringService suit test', () => {
         };
 
         expect(construction).to.throw(
-            'TCStringService, tcStringCookieName parameter must be a string with a length greater than zero.',
+            'TCStringService.tcStringCookieName must be a not empty string.',
         );
 
     });
@@ -192,6 +192,8 @@ describe('TCStringService suit test', () => {
             vendorListVersion: globalTCModel.vendorListVersion,
             supportedLanguages: ['fr', 'en'],
             userLanguage: 'it',
+            purposeIds: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+            purposeIdsForPartialCheck: [1],
             result: false,
         },
         {
@@ -202,6 +204,20 @@ describe('TCStringService suit test', () => {
             vendorListVersion: globalTCModel.vendorListVersion,
             supportedLanguages: ['fr', 'en'],
             userLanguage: 'it',
+            purposeIds: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+            purposeIdsForPartialCheck: [1],
+            result: true,
+        },
+        {
+            title: 'TCStringService is valid tcString when expirationDaysForPartialConsents is exceeded but skip the partial consent check test',
+            subtractDaysFromNow: 6,
+            expirationDaysForPartialConsents: 5,
+            cmpVersion: globalTCModel.cmpVersion,
+            vendorListVersion: globalTCModel.vendorListVersion,
+            supportedLanguages: ['fr', 'en'],
+            userLanguage: 'it',
+            purposeIds: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+            purposeIdsForPartialCheck: [],
             result: true,
         },
         {
@@ -212,16 +228,44 @@ describe('TCStringService suit test', () => {
             vendorListVersion: globalTCModel.vendorListVersion,
             supportedLanguages: ['fr', 'en'],
             userLanguage: 'it',
+            purposeIds: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+            purposeIdsForPartialCheck: [1],
             result: false,
         },
         {
-            title: 'TCStringService is invalid tcString with different vendor list version used test',
+            title: 'TCStringService is invalid tcString with different vendor list version used and consent is not partial test',
             subtractDaysFromNow: 5,
             expirationDaysForPartialConsents: 6,
             cmpVersion: globalTCModel.cmpVersion,
             vendorListVersion: Number(globalTCModel.vendorListVersion) + 1,
             supportedLanguages: ['fr', 'en'],
             userLanguage: 'it',
+            purposeIds: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+            purposeIdsForPartialCheck: [1],
+            result: true,
+        },
+        {
+            title: 'TCStringService is invalid tcString with different vendor list version used and consent is partial test',
+            subtractDaysFromNow: 5,
+            expirationDaysForPartialConsents: 6,
+            cmpVersion: globalTCModel.cmpVersion,
+            vendorListVersion: Number(globalTCModel.vendorListVersion) + 1,
+            supportedLanguages: ['fr', 'en'],
+            userLanguage: 'it',
+            purposeIds: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+            purposeIdsForPartialCheck: [1],
+            result: false,
+        },
+        {
+            title: 'TCStringService is invalid tcString with different vendor list version used and partial check is skipped test',
+            subtractDaysFromNow: 5,
+            expirationDaysForPartialConsents: 6,
+            cmpVersion: globalTCModel.cmpVersion,
+            vendorListVersion: Number(globalTCModel.vendorListVersion) + 1,
+            supportedLanguages: ['fr', 'en'],
+            userLanguage: 'it',
+            purposeIds: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+            purposeIdsForPartialCheck: [],
             result: false,
         },
         {
@@ -232,6 +276,8 @@ describe('TCStringService suit test', () => {
             vendorListVersion: globalTCModel.vendorListVersion,
             supportedLanguages: ['fr', 'en', 'it'],
             userLanguage: 'it',
+            purposeIds: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+            purposeIdsForPartialCheck: [1],
             result: false,
         },
         {
@@ -242,6 +288,8 @@ describe('TCStringService suit test', () => {
             vendorListVersion: globalTCModel.vendorListVersion,
             supportedLanguages: ['fr', 'en'],
             userLanguage: 'it',
+            purposeIds: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+            purposeIdsForPartialCheck: [1],
             result: true,
         },
         {
@@ -252,6 +300,8 @@ describe('TCStringService suit test', () => {
             vendorListVersion: globalTCModel.vendorListVersion,
             supportedLanguages: ['fr', 'en'],
             userLanguage: 'it',
+            purposeIds: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+            purposeIdsForPartialCheck: [1],
             result: true,
         },
     ];
@@ -269,7 +319,8 @@ describe('TCStringService suit test', () => {
             createdDate.setDate(createdDate.getDate() - subtractDaysFromNow);
             tcModel.created = createdDate;
 
-            tcModel.purposeConsents.unset(1);
+            tcModel.purposeConsents.unset([...tcModel.purposeConsents.values()]);
+            tcModel.purposeConsents.set(testData.purposeIds);
 
             tcModel.gvl = new GVL(require('@iabtcf/testing/lib/vendorlist/vendor-list.json'));
 
@@ -287,6 +338,8 @@ describe('TCStringService suit test', () => {
                 Number(testData.cmpVersion),
                 Number(testData.vendorListVersion),
                 'solo-cmp-tc-string',
+                NaN,
+                testData.purposeIdsForPartialCheck,
                 expirationDaysForPartialConsents,
             );
 


### PR DESCRIPTION
The goal of this feature is to implement a lazy mechanism that popup the UI to the user (to update the consent with the new vendor list version) only if the consent is partial otherwise keep the old.

close #96 