### PR TITLE
[#99] Add parameter to choose to apply legitimate basis even on legitimate interests

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ const soloCmp = new SoloCmp(
     enableBorderAmpCmpUi: false, // Amp configuration this configure the border of the CMP running in an AMP environment.
     skipACStringCheck: false, // This parameter, if configured to true, allows to avoid the validation code of the ACString.
     isLegitimateInterestDisabled: false, // This parameter, if configured to true, allows to skip the legitimate interest build.
+    legitimateMirror: true, // If configured to true, the consents for legitimate interest will be enabled or disabled in the same way as basic consents.
     expireTCStringInDays: 180, // Provide for how much days the TCString should be valid.
     purposeIdsForPartialCheck: [], // Here you can provide an array of purpose ids that the validation logic used to check if the consent is partial when these purpose ids are not enabled.
     expirationDaysForPartialConsents: null // This parameter, if configured with a Number, allows the preventive expiration of the tcString when purpose 1 is not enabled.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pubtech-ai/solo-cmp",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pubtech-ai/solo-cmp",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@iabtcf/cmpapi": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pubtech-ai/solo-cmp",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Wrapper of IAB module that make simple to made a CMP",
   "author": "Marco Prontera <https://github.com/Marco-Prontera>",
   "license": "Apache-2.0",

--- a/src/Dto/SoloCmpDto.ts
+++ b/src/Dto/SoloCmpDto.ts
@@ -24,6 +24,7 @@ export interface SoloCmpDto {
     enableBorderAmpCmpUi: boolean | null;
     skipACStringCheck: boolean;
     isLegitimateInterestDisabled: boolean;
+    legitimateMirror: boolean;
     expireTCStringInDays: number;
     purposeIdsForPartialCheck: number[];
     expirationDaysForPartialConsents: number | null;

--- a/src/Service/ConsentGeneratorService.ts
+++ b/src/Service/ConsentGeneratorService.ts
@@ -15,7 +15,8 @@ export class ConsentGeneratorService {
     private tcStringService: TCStringService;
     private acStringService: ACStringService;
     private eventDispatcher: EventDispatcher;
-    private isLegitimateInterestDisabled: boolean;
+    private readonly isLegitimateInterestDisabled: boolean;
+    private readonly legitimateMirror: boolean;
 
     /**
      * Constructor.
@@ -24,18 +25,21 @@ export class ConsentGeneratorService {
      * @param {ACStringService} acStringService
      * @param {EventDispatcher} eventDispatcher
      * @param {boolean} isLegitimateInterestDisabled
+     * @param {boolean} legitimateMirror
      */
     constructor(
         tcStringService: TCStringService,
         acStringService: ACStringService,
         eventDispatcher: EventDispatcher,
         isLegitimateInterestDisabled: boolean,
+        legitimateMirror: boolean,
     ) {
 
         this.tcStringService = tcStringService;
         this.acStringService = acStringService;
         this.eventDispatcher = eventDispatcher;
         this.isLegitimateInterestDisabled = isLegitimateInterestDisabled;
+        this.legitimateMirror = legitimateMirror;
 
     }
 
@@ -47,7 +51,12 @@ export class ConsentGeneratorService {
      */
     public generateAndPersistConsent(soloCmpDataBundle: SoloCmpDataBundle): void {
 
-        const choicesParser = new UIChoicesParser(soloCmpDataBundle.tcModel, soloCmpDataBundle.acModel);
+        const choicesParser = new UIChoicesParser(
+            soloCmpDataBundle.tcModel,
+            soloCmpDataBundle.acModel,
+            this.isLegitimateInterestDisabled,
+            this.legitimateMirror,
+        );
 
         const tcModel = choicesParser.parseTCModel(soloCmpDataBundle.uiChoicesBridgeDto);
         const acModel = choicesParser.parseACModel(soloCmpDataBundle.uiChoicesBridgeDto);
@@ -64,8 +73,14 @@ export class ConsentGeneratorService {
      */
     public generateAndPersistConsentWithAllEnabled(soloCmpDataBundle: SoloCmpDataBundle): void {
 
-        const choicesParser = new UIChoicesParser(soloCmpDataBundle.tcModel, soloCmpDataBundle.acModel);
-        const tcModel = choicesParser.buildTCModelAllEnabled(this.isLegitimateInterestDisabled);
+        const choicesParser = new UIChoicesParser(
+            soloCmpDataBundle.tcModel,
+            soloCmpDataBundle.acModel,
+            this.isLegitimateInterestDisabled,
+            this.legitimateMirror,
+        );
+
+        const tcModel = choicesParser.buildTCModelAllEnabled();
         const acModel = choicesParser.buildACModelAllEnabled();
 
         this.dispatchReadyAndPersist(tcModel, acModel);

--- a/src/SoloCmp.ts
+++ b/src/SoloCmp.ts
@@ -53,6 +53,7 @@ export class SoloCmp {
     private readonly enableBorderAmpCmpUi: boolean | null = null;
     private readonly skipACStringCheck: boolean;
     private readonly isLegitimateInterestDisabled: boolean;
+    private readonly legitimateMirror: boolean;
     private readonly expireTCStringInDays: number;
     private readonly purposeIdsForPartialCheck: number[];
     private readonly expirationDaysForPartialConsents: number | null;
@@ -82,6 +83,7 @@ export class SoloCmp {
         this.enableBorderAmpCmpUi = soloCmpDto.enableBorderAmpCmpUi;
         this.skipACStringCheck = soloCmpDto.skipACStringCheck;
         this.isLegitimateInterestDisabled = soloCmpDto.isLegitimateInterestDisabled;
+        this.legitimateMirror = soloCmpDto.legitimateMirror;
         this.expireTCStringInDays = soloCmpDto.expireTCStringInDays;
         this.purposeIdsForPartialCheck = soloCmpDto.purposeIdsForPartialCheck;
         this.expirationDaysForPartialConsents = soloCmpDto.expirationDaysForPartialConsents;
@@ -223,6 +225,7 @@ export class SoloCmp {
                     container[ACStringService.getClassName()],
                     container[EventDispatcher.getClassName()],
                     this.isLegitimateInterestDisabled,
+                    this.legitimateMirror,
                 );
 
             });

--- a/test/UIChoicesBridge/UIChoicesParser.test.ts
+++ b/test/UIChoicesBridge/UIChoicesParser.test.ts
@@ -7,82 +7,225 @@ import {UIChoicesBridgeDtoBuilder, UIChoicesParser} from '../../src/UIChoicesBri
 
 describe('UIChoicesParser suit test', () => {
 
-    it('UIChoicesParser parsing logic validation test', () => {
+    /**
+     * Test the condition for the expiration days for partial consent.
+     */
+    const testFixtureForParsingLogic = [
+        {
+            title: 'UIChoicesParser parsing logic with leg int disabled validation test',
+            isLegitimateInterestDisabled: true,
+            legitimateMirror: false,
+            firstTimeConsentRequest: true,
+            expectations: {
+                purposeConsents: 0,
+                googleVendorOptions: 2,
+                enabled: {
+                    publisherConsents: 10,
+                    publisherLegitimateInterests: 0,
+                    purposeConsents: 10,
+                    vendorConsents: 736,
+                    purposeLegitimateInterests: 0,
+                    vendorLegitimateInterests: 0,
+                    specialFeatureOptins: 1,
+                    googleVendorOptions: 1,
+                    allSpecialFeatureOptins: 2,
+                },
+            },
+        },
+        {
+            title: 'UIChoicesParser parsing logic with leg int disabled and mirror enabled validation test',
+            isLegitimateInterestDisabled: true,
+            legitimateMirror: true,
+            firstTimeConsentRequest: true,
+            expectations: {
+                purposeConsents: 0,
+                googleVendorOptions: 2,
+                enabled: {
+                    publisherConsents: 10,
+                    publisherLegitimateInterests: 9,
+                    purposeConsents: 10,
+                    vendorConsents: 736,
+                    purposeLegitimateInterests: 9,
+                    vendorLegitimateInterests: 736,
+                    specialFeatureOptins: 1,
+                    googleVendorOptions: 1,
+                    allSpecialFeatureOptins: 2,
+                },
+            },
+        },
+        {
+            title: 'UIChoicesParser parsing logic with leg int enabled and mirror disabled validation test',
+            isLegitimateInterestDisabled: false,
+            legitimateMirror: false,
+            firstTimeConsentRequest: true,
+            expectations: {
+                purposeConsents: 0,
+                googleVendorOptions: 2,
+                enabled: {
+                    publisherConsents: 10,
+                    publisherLegitimateInterests: 9,
+                    purposeConsents: 10,
+                    vendorConsents: 736,
+                    purposeLegitimateInterests: 9,
+                    vendorLegitimateInterests: 290,
+                    specialFeatureOptins: 1,
+                    googleVendorOptions: 1,
+                    allSpecialFeatureOptins: 2,
+                },
+            },
+        },
+        {
+            title: 'UIChoicesParser parsing logic with leg int enabled and mirror enabled validation test',
+            isLegitimateInterestDisabled: false,
+            legitimateMirror: true,
+            firstTimeConsentRequest: true,
+            expectations: {
+                purposeConsents: 0,
+                googleVendorOptions: 2,
+                enabled: {
+                    publisherConsents: 10,
+                    publisherLegitimateInterests: 9,
+                    purposeConsents: 10,
+                    vendorConsents: 736,
+                    purposeLegitimateInterests: 9,
+                    vendorLegitimateInterests: 736,
+                    specialFeatureOptins: 1,
+                    googleVendorOptions: 1,
+                    allSpecialFeatureOptins: 2,
+                },
+            },
+        },
+        {
+            title: 'UIChoicesParser parsing logic with leg int enabled and mirror enabled validation test',
+            isLegitimateInterestDisabled: false,
+            legitimateMirror: true,
+            firstTimeConsentRequest: false,
+            expectations: {
+                purposeConsents: 0,
+                googleVendorOptions: 2,
+                enabled: {
+                    publisherConsents: 10,
+                    publisherLegitimateInterests: 9,
+                    purposeConsents: 10,
+                    vendorConsents: 2,
+                    purposeLegitimateInterests: 9,
+                    vendorLegitimateInterests: 2,
+                    specialFeatureOptins: 1,
+                    googleVendorOptions: 1,
+                    allSpecialFeatureOptins: 2,
+                },
+            },
+        },
+        {
+            title: 'UIChoicesParser parsing logic with leg int enabled and mirror disabled validation not first time consent test',
+            isLegitimateInterestDisabled: true,
+            legitimateMirror: false,
+            firstTimeConsentRequest: false,
+            expectations: {
+                purposeConsents: 0,
+                googleVendorOptions: 2,
+                enabled: {
+                    publisherConsents: 10,
+                    publisherLegitimateInterests: 0,
+                    purposeConsents: 10,
+                    vendorConsents: 2,
+                    purposeLegitimateInterests: 0,
+                    vendorLegitimateInterests: 0,
+                    specialFeatureOptins: 1,
+                    googleVendorOptions: 1,
+                    allSpecialFeatureOptins: 2,
+                },
+            },
+        },
+    ];
 
-        const tcModelInit: TCModel = getTCModelByFixture();
-        const acModelInit: ACModel = getACModelByFixture();
+    testFixtureForParsingLogic.forEach((testData) => {
 
-        const uiChoicesParser = new UIChoicesParser(tcModelInit, acModelInit);
+        it(testData.title, () => {
 
-        const choicesStateHandler = new UIChoicesBridgeDtoBuilder(
-            tcModelInit,
-            acModelInit,
-            true,
-            false,
-        ).createUIChoicesBridgeDto();
+            const tcModelInit: TCModel = getTCModelByFixture();
+            const acModelInit: ACModel = getACModelByFixture();
 
-        // Simulate User choices changes
-        choicesStateHandler.UIPurposeChoices.forEach((purposeChoice) => (purposeChoice.state = true));
-        choicesStateHandler.UILegitimateInterestsPurposeChoices[0].state = true;
-        choicesStateHandler.UISpecialFeatureChoices[0].state = true;
+            const uiChoicesParser = new UIChoicesParser(
+                tcModelInit,
+                acModelInit,
+                testData.isLegitimateInterestDisabled,
+                testData.legitimateMirror,
+            );
 
-        expect(
-            [...uiChoicesParser.tcModel.purposeConsents.values()].length,
-            '[...uiChoicesParser.tcModel.purposeConsents.values()].length',
-        ).to.equal(0);
-        expect(
-            uiChoicesParser.acModel.googleVendorOptions.length,
-            'uiChoicesParser.acModel.googleVendorOptions.length',
-        ).to.equal(2);
+            const choicesStateHandler = new UIChoicesBridgeDtoBuilder(
+                tcModelInit,
+                acModelInit,
+                testData.firstTimeConsentRequest,
+                testData.isLegitimateInterestDisabled,
+            ).createUIChoicesBridgeDto();
 
-        let tcModel = uiChoicesParser.parseTCModel(choicesStateHandler);
+            // Simulate User choices changes
+            choicesStateHandler.UIPurposeChoices.forEach((purposeChoice) => (purposeChoice.state = true));
+            choicesStateHandler.UISpecialFeatureChoices[0].state = true;
 
-        expect(
-            [...tcModel.publisherConsents.values()].length,
-            '[...tcModel.publisherConsents.values()].length',
-        ).to.equal(10);
+            expect(
+                [...uiChoicesParser.tcModel.purposeConsents.values()].length,
+                '[...uiChoicesParser.tcModel.purposeConsents.values()].length',
+            ).to.equal(testData.expectations.purposeConsents);
+            expect(
+                uiChoicesParser.acModel.googleVendorOptions.length,
+                'uiChoicesParser.acModel.googleVendorOptions.length',
+            ).to.equal(testData.expectations.googleVendorOptions);
 
-        expect(
-            [...tcModel.publisherLegitimateInterests.values()].length,
-            '[...tcModel.publisherLegitimateInterests.values()].length',
-        ).to.equal(9);
+            let tcModel = uiChoicesParser.parseTCModel(choicesStateHandler);
 
-        expect([...tcModel.purposeConsents.values()].length, '[...tcModel.purposeConsents.values()].length').to.equal(
-            10,
-        );
-        expect([...tcModel.vendorConsents.values()].length, '[...tcModel.vendorConsents.values()].length').to.equal(
-            736,
-        );
-        expect(
-            [...tcModel.vendorLegitimateInterests.values()].length,
-            '[...tcModel.vendorLegitimateInterests.values()].length',
-        ).to.equal(290);
+            expect(
+                [...tcModel.publisherConsents.values()].length,
+                '[...tcModel.publisherConsents.values()].length',
+            ).to.equal(testData.expectations.enabled.publisherConsents);
 
-        let acModel = uiChoicesParser.parseACModel(choicesStateHandler);
+            expect(
+                [...tcModel.publisherLegitimateInterests.values()].length,
+                '[...tcModel.publisherLegitimateInterests.values()].length',
+            ).to.equal(testData.expectations.enabled.publisherLegitimateInterests);
 
-        expect(
-            [...acModel.googleVendorOptions.filter((option) => option.state)].length,
-            '[...acModel.googleVendorOptions.filter(option => option.state)].length',
-        ).to.equal(1);
+            expect([...tcModel.purposeConsents.values()].length, '[...tcModel.purposeConsents.values()].length').to.equal(
+                testData.expectations.enabled.purposeConsents,
+            );
+            expect([...tcModel.vendorConsents.values()].length, '[...tcModel.vendorConsents.values()].length').to.equal(
+                testData.expectations.enabled.vendorConsents,
+            );
+            expect([...tcModel.purposeLegitimateInterests.values()].length, '[...tcModel.purposeLegitimateInterests.values()].length').to.equal(
+                testData.expectations.enabled.purposeLegitimateInterests,
+            );
+            expect(
+                [...tcModel.vendorLegitimateInterests.values()].length,
+                '[...tcModel.vendorLegitimateInterests.values()].length',
+            ).to.equal(testData.expectations.enabled.vendorLegitimateInterests);
 
-        acModel = uiChoicesParser.buildACModelAllEnabled();
+            let acModel = uiChoicesParser.parseACModel(choicesStateHandler);
 
-        expect(
-            [...acModel.googleVendorOptions.filter((option) => option.state)].length,
-            'enabled all [...acModel.googleVendorOptions.filter(option => option.state)].length',
-        ).to.equal(acModel.googleVendorOptions.length);
+            expect(
+                [...acModel.googleVendorOptions.filter((option) => option.state)].length,
+                '[...acModel.googleVendorOptions.filter(option => option.state)].length',
+            ).to.equal(testData.expectations.enabled.googleVendorOptions);
 
-        expect(
-            [...tcModel.specialFeatureOptins.values()].length,
-            '[...tcModel.specialFeatureOptins.values()].length',
-        ).to.equal(1);
+            acModel = uiChoicesParser.buildACModelAllEnabled();
 
-        tcModel = uiChoicesParser.buildTCModelAllEnabled(true);
+            expect(
+                [...acModel.googleVendorOptions.filter((option) => option.state)].length,
+                'enabled all [...acModel.googleVendorOptions.filter(option => option.state)].length',
+            ).to.equal(acModel.googleVendorOptions.length);
 
-        expect(
-            [...tcModel.specialFeatureOptins.values()].length,
-            '[...tcModel.specialFeatureOptins.values()].length',
-        ).to.equal(2);
+            expect(
+                [...tcModel.specialFeatureOptins.values()].length,
+                '[...tcModel.specialFeatureOptins.values()].length',
+            ).to.equal(testData.expectations.enabled.specialFeatureOptins);
+
+            tcModel = uiChoicesParser.buildTCModelAllEnabled();
+
+            expect(
+                [...tcModel.specialFeatureOptins.values()].length,
+                '[...tcModel.specialFeatureOptins.values()].length',
+            ).to.equal(testData.expectations.enabled.allSpecialFeatureOptins);
+
+        });
 
     });
 


### PR DESCRIPTION
The goal of this PR:
- Add the parameter legitimateMirror when true the legitimate interests will have the same settings of the legitimate basis choices of the user.

close #99 