### PR TITLE
[#94] Update IAB dependency for Reduction of the timestamps’ precision in the TC String

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pubtech-ai/solo-cmp",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pubtech-ai/solo-cmp",
-      "version": "2.2.2",
+      "version": "2.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@iabtcf/cmpapi": "1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "2.2.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@iabtcf/cmpapi": "1.3.1",
-        "@iabtcf/core": "1.3.1",
-        "@iabtcf/stub": "1.3.1",
+        "@iabtcf/cmpapi": "1.4.0",
+        "@iabtcf/core": "1.4.0",
+        "@iabtcf/stub": "1.4.0",
         "bottlejs": "2.0.0"
       },
       "devDependencies": {
@@ -156,22 +156,22 @@
       "dev": true
     },
     "node_modules/@iabtcf/cmpapi": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@iabtcf/cmpapi/-/cmpapi-1.3.1.tgz",
-      "integrity": "sha512-t60awD6WJTK/VVOB3dIyQXcYrZ5sjuRas9pbGAOLfYv3s57oIq6Qa8clEG1ordHVDXWPBbcafygcDh2EH48bDw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@iabtcf/cmpapi/-/cmpapi-1.4.0.tgz",
+      "integrity": "sha512-WZCgLZ3s6cL8twh4mm9W/dhWtwFbEdgFWcYNCuI6b4l0wpjG5th82EnHWpaEJyDFVhzvXkG6IybaJ2R1mk/vcg==",
       "peerDependencies": {
         "@iabtcf/core": ">=1.0.0"
       }
     },
     "node_modules/@iabtcf/core": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@iabtcf/core/-/core-1.3.1.tgz",
-      "integrity": "sha512-t3ZvQRXLhoze2cx15mZMt5wUVhj+q3CoXtSSdZuVbrEbnyzFJ6uW0fxr5dmH1vRud7QYGRXqjhCBL7Yr46VRpA=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@iabtcf/core/-/core-1.4.0.tgz",
+      "integrity": "sha512-LfyscG/rNhw542MX4pNSBPzK3ddHDYB8cz7pNTOI6D664x7jJmVZjkRmw8X/h9yGQ2c0a/1AP9F8n5/UsxKjeA=="
     },
     "node_modules/@iabtcf/stub": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@iabtcf/stub/-/stub-1.3.1.tgz",
-      "integrity": "sha512-mT39WLn/aRdxqA+3wEUCRElgunCYCqWeUrFLl1wTS8K91iMAIFgVH1It0DHYhy0goKQUSkJ+E8MurcSKgpRmCw=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@iabtcf/stub/-/stub-1.4.0.tgz",
+      "integrity": "sha512-TPspVaebewXPga0rtmNUqtidBz84e+8I08CJz8kup6VCVVNuORvBFAcTPcHV6tz+NaOW5mfAHsaXARVou1q+Gg=="
     },
     "node_modules/@iabtcf/testing": {
       "version": "1.3.1",
@@ -6298,20 +6298,20 @@
       "dev": true
     },
     "@iabtcf/cmpapi": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@iabtcf/cmpapi/-/cmpapi-1.3.1.tgz",
-      "integrity": "sha512-t60awD6WJTK/VVOB3dIyQXcYrZ5sjuRas9pbGAOLfYv3s57oIq6Qa8clEG1ordHVDXWPBbcafygcDh2EH48bDw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@iabtcf/cmpapi/-/cmpapi-1.4.0.tgz",
+      "integrity": "sha512-WZCgLZ3s6cL8twh4mm9W/dhWtwFbEdgFWcYNCuI6b4l0wpjG5th82EnHWpaEJyDFVhzvXkG6IybaJ2R1mk/vcg==",
       "requires": {}
     },
     "@iabtcf/core": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@iabtcf/core/-/core-1.3.1.tgz",
-      "integrity": "sha512-t3ZvQRXLhoze2cx15mZMt5wUVhj+q3CoXtSSdZuVbrEbnyzFJ6uW0fxr5dmH1vRud7QYGRXqjhCBL7Yr46VRpA=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@iabtcf/core/-/core-1.4.0.tgz",
+      "integrity": "sha512-LfyscG/rNhw542MX4pNSBPzK3ddHDYB8cz7pNTOI6D664x7jJmVZjkRmw8X/h9yGQ2c0a/1AP9F8n5/UsxKjeA=="
     },
     "@iabtcf/stub": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@iabtcf/stub/-/stub-1.3.1.tgz",
-      "integrity": "sha512-mT39WLn/aRdxqA+3wEUCRElgunCYCqWeUrFLl1wTS8K91iMAIFgVH1It0DHYhy0goKQUSkJ+E8MurcSKgpRmCw=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@iabtcf/stub/-/stub-1.4.0.tgz",
+      "integrity": "sha512-TPspVaebewXPga0rtmNUqtidBz84e+8I08CJz8kup6VCVVNuORvBFAcTPcHV6tz+NaOW5mfAHsaXARVou1q+Gg=="
     },
     "@iabtcf/testing": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     "url": "git://github.com/pubtech-ai/solo-cmp.git"
   },
   "dependencies": {
-    "@iabtcf/cmpapi": "1.3.1",
-    "@iabtcf/core": "1.3.1",
-    "@iabtcf/stub": "1.3.1",
+    "@iabtcf/cmpapi": "1.4.0",
+    "@iabtcf/core": "1.4.0",
+    "@iabtcf/stub": "1.4.0",
     "bottlejs": "2.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pubtech-ai/solo-cmp",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "description": "Wrapper of IAB module that make simple to made a CMP",
   "author": "Marco Prontera <https://github.com/Marco-Prontera>",
   "license": "Apache-2.0",


### PR DESCRIPTION
The goal of this PR:
- Update the IAB dependency to the latest [1.4.0](https://github.com/InteractiveAdvertisingBureau/iabtcf-es/releases/tag/v1.4.0) version